### PR TITLE
Faster and simpler floating-point truncation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ $(libshared): $(object)
 
 # Generate the full source listing using the C preprocessor:
 $(unified_source): $(src) $(geninc)
-	cpp -I$(genincdir) $(src) | sed '/^#/d' > $(unified_source)
+	cpp -w -I$(genincdir) $(src) | sed '/^#/d' > $(unified_source)
 
 # Test the built library.
 test: library

--- a/doc/api/rp_emulator.rst
+++ b/doc/api/rp_emulator.rst
@@ -72,6 +72,23 @@ Variables
    This option only affects the emulation when emulating a 10-bit significand.
 
 
+.. f:variable:: RPE_FAST_MODE
+   :type: LOGICAL
+   :attrs: default=.FALSE.
+
+   Logical value determining whether or not to use a faster algorithm to reduced precision.
+   The faster algorithm uses floating-point operations to bit-shift the value to the required precision, and takes approximately 2/3 of the time as the standard algorithm.
+
+   .. note::
+
+      With ``RPE_FAST_MODE=.TRUE.`` the results will not be the same as with ``RPE_FAST_MODE=.FALSE.`` due to differences in rounding schemes.
+
+   .. warning::
+
+      It is possible that this scheme will generate overflow errors when working with extremely large numbers truncated to a small number of bits.
+      If this affects you then you should not use this mode.
+
+
 Parameters
 ==========
 

--- a/test/unit/common/suite_common.f90
+++ b/test/unit/common/suite_common.f90
@@ -24,12 +24,12 @@ MODULE suite_common
     !
     !  hexadecimal: 0x408C86A761308B4C
     !  binary: 0100000010001100100001101010011101100001001100001000101101001100
-    !  floating-point: 912.831728343249324097996577621
+    !  floating-point: 912.8317283432493
     !
     REAL(KIND=RPE_REAL_KIND), PARAMETER :: utest64 = z'408C86A761308B4C'
     !
     ! An array storing the same number at significand precisions from 1 to 23
-    ! bits. These truncated representations are rounded ocrrectly.
+    ! bits. These truncated representations are rounded correctly.
     !
     REAL(KIND=RPE_REAL_KIND), PARAMETER, DIMENSION(23) :: utest64_t = (/ &
         REAL(z'4090000000000000', RPE_REAL_KIND), & ! 1 (rounds into exponent)
@@ -55,6 +55,77 @@ MODULE suite_common
         REAL(z'408C86A780000000', RPE_REAL_KIND), & ! 21
         REAL(z'408C86A780000000', RPE_REAL_KIND), & ! 22
         REAL(z'408C86A760000000', RPE_REAL_KIND)  & ! 23
+    /)
+
+    ! A double precision floating-point number used for testing reduction
+    ! of precision. This particular choice includes an exponent incursion
+    ! at 1 bit of precision and a case where extra IEEE rounding rules will
+    ! be invoked to avoid rounding bias.. The number has the following
+    ! representations:
+    !
+    !  hexadecimal: 0x408C86A761308B44
+    !  binary: 0100000010001100100001101010011101100001001100001000101101000100
+    !  floating-point: 912.8317283432484
+    !
+    REAL(KIND=RPE_REAL_KIND), PARAMETER :: utest64_ieee = z'408c86a761308b44'
+    !
+    ! An array storing the same number at significand precisions from 1 to 23
+    ! bits. These truncated representations are rounded correctly (including
+    ! IEEE 'round to even' rule).
+    !
+    REAL(KIND=RPE_REAL_KIND), PARAMETER, DIMENSION(52) :: utest64_ieee_t = (/ &
+        REAL(z'4090000000000000', RPE_REAL_KIND), & ! 1
+        REAL(z'408C000000000000', RPE_REAL_KIND), & ! 2
+        REAL(z'408C000000000000', RPE_REAL_KIND), & ! 3
+        REAL(z'408D000000000000', RPE_REAL_KIND), & ! 4
+        REAL(z'408C800000000000', RPE_REAL_KIND), & ! 5
+        REAL(z'408C800000000000', RPE_REAL_KIND), & ! 6
+        REAL(z'408C800000000000', RPE_REAL_KIND), & ! 7
+        REAL(z'408C800000000000', RPE_REAL_KIND), & ! 8
+        REAL(z'408C880000000000', RPE_REAL_KIND), & ! 9
+        REAL(z'408C880000000000', RPE_REAL_KIND), & ! 10
+        REAL(z'408C860000000000', RPE_REAL_KIND), & ! 11
+        REAL(z'408C870000000000', RPE_REAL_KIND), & ! 12
+        REAL(z'408C868000000000', RPE_REAL_KIND), & ! 13
+        REAL(z'408C86C000000000', RPE_REAL_KIND), & ! 14
+        REAL(z'408C86A000000000', RPE_REAL_KIND), & ! 15
+        REAL(z'408C86A000000000', RPE_REAL_KIND), & ! 16
+        REAL(z'408C86A800000000', RPE_REAL_KIND), & ! 17
+        REAL(z'408C86A800000000', RPE_REAL_KIND), & ! 18
+        REAL(z'408C86A800000000', RPE_REAL_KIND), & ! 19
+        REAL(z'408C86A700000000', RPE_REAL_KIND), & ! 20
+        REAL(z'408C86A780000000', RPE_REAL_KIND), & ! 21
+        REAL(z'408C86A780000000', RPE_REAL_KIND), & ! 22
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 23
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 24
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 25
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 26
+        REAL(z'408C86A762000000', RPE_REAL_KIND), & ! 27
+        REAL(z'408C86A761000000', RPE_REAL_KIND), & ! 28
+        REAL(z'408C86A761000000', RPE_REAL_KIND), & ! 29
+        REAL(z'408C86A761400000', RPE_REAL_KIND), & ! 30
+        REAL(z'408C86A761400000', RPE_REAL_KIND), & ! 31
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 32
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 33
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 34
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 35
+        REAL(z'408C86A761310000', RPE_REAL_KIND), & ! 36
+        REAL(z'408C86A761308000', RPE_REAL_KIND), & ! 37
+        REAL(z'408C86A761308000', RPE_REAL_KIND), & ! 38
+        REAL(z'408C86A761308000', RPE_REAL_KIND), & ! 39
+        REAL(z'408C86A761309000', RPE_REAL_KIND), & ! 40
+        REAL(z'408C86A761308800', RPE_REAL_KIND), & ! 41
+        REAL(z'408C86A761308C00', RPE_REAL_KIND), & ! 42
+        REAL(z'408C86A761308C00', RPE_REAL_KIND), & ! 43
+        REAL(z'408C86A761308B00', RPE_REAL_KIND), & ! 44
+        REAL(z'408C86A761308B80', RPE_REAL_KIND), & ! 45
+        REAL(z'408C86A761308B40', RPE_REAL_KIND), & ! 46
+        REAL(z'408C86A761308B40', RPE_REAL_KIND), & ! 47
+        REAL(z'408C86A761308B40', RPE_REAL_KIND), & ! 48
+        REAL(z'408C86A761308B40', RPE_REAL_KIND), & ! 49
+        REAL(z'408C86A761308B44', RPE_REAL_KIND), & ! 50
+        REAL(z'408C86A761308B44', RPE_REAL_KIND), & ! 51
+        REAL(z'408C86A761308B44', RPE_REAL_KIND)  & ! 52
     /)
     
     REAL(KIND=RPE_ALTERNATE_KIND), PARAMETER :: utest32 = z'404ccccd'

--- a/test/unit/core/test_apply_truncation.pf
+++ b/test/unit/core/test_apply_truncation.pf
@@ -16,7 +16,9 @@ MODULE test_apply_truncation
 ! Tests for the apply_truncation subroutine
 !
     USE pfunit_mod
-    USE suite_common, ONLY : utest64, min_significand_bits
+    USE suite_common, ONLY : utest64, utest64_t, &
+                             utest64_ieee, utest64_ieee_t, &
+                             min_significand_bits
     USE rp_emulator
     IMPLICIT NONE
 
@@ -25,6 +27,7 @@ MODULE test_apply_truncation
         LOGICAL :: rpe_active
         INTEGER :: rpe_default_sbits
         LOGICAL :: rpe_ieee_half
+        LOGICAL :: rpe_fast_mode
     CONTAINS
         procedure :: setUp
         procedure :: tearDown
@@ -37,6 +40,7 @@ CONTAINS
         this%rpe_active = RPE_ACTIVE
         this%rpe_default_sbits = RPE_DEFAULT_SBITS
         this%rpe_ieee_half = RPE_IEEE_HALF
+        this%rpe_fast_mode = RPE_FAST_MODE
     END SUBROUTINE setUp
 
     SUBROUTINE tearDown (this)
@@ -44,7 +48,38 @@ CONTAINS
         RPE_ACTIVE = this%rpe_active
         RPE_DEFAULT_SBITS = this%rpe_default_sbits
         RPE_IEEE_HALF = this%rpe_ieee_half
+        RPE_FAST_MODE = this%rpe_fast_mode
     END SUBROUTINE tearDown
+
+    @TEST
+    SUBROUTINE test_apply_truncation_invalid_sbits_high (context)
+    ! Test that nothing different happens to values when the number
+    ! of significand bits is greater than 52.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+
+        reduced%sbits = 99
+        reduced = utest64
+        @ASSERTEQUAL(reduced%val, utest64)
+
+        reduced%sbits = 53
+        reduced = utest64
+        @ASSERTEQUAL(reduced%val, utest64)
+    END SUBROUTINE test_apply_truncation_invalid_sbits_high
+
+    @TEST
+    SUBROUTINE test_apply_truncation_invalid_sbits_low (context)
+    ! Test that nothing different happens to values when the number
+    ! of significand bits is greater less than 0.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+
+        reduced%sbits = -99
+        reduced = utest64
+        @ASSERTEQUAL(reduced%val, utest64)
+    END SUBROUTINE test_apply_truncation_invalid_sbits_low
 
     @TEST
     SUBROUTINE test_apply_truncation_ieee_half_null (context)
@@ -109,5 +144,22 @@ CONTAINS
         @ASSERTEQUAL(-limit + 2 * delta, reduced%val)
         @ASSERTLESSTHANOREQUAL(min_significand_bits(reduced%val), 10)
     END SUBROUTINE test_apply_truncation_ieee_half_subnormal
+
+    @TEST
+    SUBROUTINE test_apply_truncation_fast_mode (context)
+    ! Test fast mode for truncation.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER :: nbits
+
+        RPE_FAST_MODE = .TRUE.
+
+        DO nbits = 1, 52
+            reduced%sbits = nbits
+            reduced = utest64_ieee
+            @ASSERTEQUAL(reduced%val, utest64_ieee_t(nbits))
+        END DO
+    END SUBROUTINE test_apply_truncation_fast_mode
 
 END MODULE test_apply_truncation


### PR DESCRIPTION
This PR adds a new method for applying significand truncation to floating-point numbers. It applies the following to compute a truncated value:

    x_t = 2^m x - (2^m - 1) x

where `x` is the value to truncate, `m` is the number of bits to truncate (`m = 52 - n` where `n` is the number of bits remaining in the significand) and `x_t` is the truncated value.

This scheme operates somewhat faster than the bitwise scheme (about 2/3 of the runtime is a simple benchmark), but is susceptible to overflow errors if working with extremely large values truncated to a small number of bits in the significand.

The scheme is currently opt-in due to both the (small) risk of overflow, and due to a slightly different rounding scheme (round to nearest, tie to even).