### PR TITLE
Add `rpe_literal` constructor functions.

### DIFF
--- a/doc/api/rp_emulator.rst
+++ b/doc/api/rp_emulator.rst
@@ -19,6 +19,50 @@ User-callable procedures
 ========================
 
 
+.. f:function:: rpe_literal (x, n)
+
+   Construct an :f:type:`rpe_var` instance from a value.
+   Optionally a number of significand bits used to store the value may be given.
+   The value will be truncated before storage.
+   A typical usage of this constructor is to support reduced precision literal values without having to declare extra variables:
+
+   .. code-block:: fortran
+
+      type(rpe_var) :: a, b, c, d, e
+
+      RPE_DEFAULT_SBITS = 10
+
+      ! variables a, b and c have a 10-bit significands:
+      a = 5.00
+      b = 7.23
+      c = 21.12
+
+      ! The literals 7.29e-5, 3.14 and 18.17 have full precision
+      ! (a 23-bit significand):
+      d = 7.29e-5 * a + 3.14 * b + 18.17 * c  ! d = 406.5
+
+      ! The literals are replaced by rpe_var instances with 10-bit significands:
+      e = rpe_literal(7.29e-5) * a + rpe_literal(3.14) * b + rpe_literal(18.17) * c  ! e = 406.75
+
+   :param x [IN]: A real or integer value to store in the resulting :f:type:`rpe_var` instance.
+   :param integer n [IN,OPTIONAL]: An optional number of significand bits used to represent the number, equivalent of setting the :f:var:`sbits` attribute of an :f:type:`rpe_var` instance. If not specified then the resulting :f:type:`rpe_var` will use the default precision specified by :f:var:`RPE_DEFAULT_SBITS`.
+
+   .. note::
+
+      If you use this to create an :f:type:`rpe_var` instance and then assign the result to another instance, only the value will be copied:
+
+      .. code-block:: fortran
+
+         ! An rpe_var instance with a 13 bit significand:
+         type(rpe_var) :: a
+         a%sbits = 13
+
+         ! Construct an rpe_type instance with a 15-bit significand and assign to a,
+         ! the value will be truncated to 13 bits and the variable a will continue
+         ! to store only 13 significand bits.
+         a = rpe_literal(1.23456789, 15)
+
+
 .. f:subroutine:: apply_truncation (rpe)
    :attrs: elemental
 

--- a/src/rp_emulator.F90
+++ b/src/rp_emulator.F90
@@ -159,7 +159,7 @@ CONTAINS
     ! Arguments:
     !
     ! * x: real(kind=RPE_DOUBLE_KIND) [input]
-    !     The doyuble precision number to truncate.
+    !     The double precision number to truncate.
     !
     ! * n: integer [input]
     !     The number of bits to truncate the significand to.
@@ -317,13 +317,13 @@ CONTAINS
     ! Arguments:
     !
     ! * x: class(*) [input]
-    !       A scalar input of any type.
+    !     A scalar input of any type.
     !
     ! Returns:
     !
     ! * z: integer [output]
-    !       The number of bits in the significand of the input floating-point
-    !       value, or 0 if the input was not a floating-point value.
+    !     The number of bits in the significand of the input floating-point
+    !     value, or 0 if the input was not a floating-point value.
     !
         CLASS(*), INTENT(IN) :: x
         INTEGER :: z

--- a/src/rp_emulator.F90
+++ b/src/rp_emulator.F90
@@ -73,6 +73,16 @@ MODULE rp_emulator
         REAL(KIND=RPE_REAL_KIND) :: val
     END TYPE
 
+    ! Create a public interface for constructing literal reduced
+    ! precision values (rpe_var instances).
+    PUBLIC rpe_literal
+    INTERFACE rpe_literal
+        MODULE PROCEDURE rpe_literal_real
+        MODULE PROCEDURE rpe_literal_alternate
+        MODULE PROCEDURE rpe_literal_integer
+        MODULE PROCEDURE rpe_literal_long
+    END INTERFACE
+
     ! Make the core emulator routines importable.
     PUBLIC :: apply_truncation, significand_bits
 
@@ -342,6 +352,119 @@ CONTAINS
             z = 0
         END SELECT
     END FUNCTION significand_bits
+
+    FUNCTION rpe_literal_real (x, n) RESULT (z)
+    ! Create an `rpe_var` instance from a real literal.
+    !
+    ! Arguments:
+    !
+    ! * x: real(kind=RPE_REAL_KIND) [input]
+    !     The literal to transform to a reduced precision `rpe_var` instance.
+    !
+    ! * n: integer [input, optional]
+    !     The number of bits in the significand of the resulting reduced
+    !     precision number. If not specified then the result will have the
+    !     default precision.
+    !
+    ! Returns:
+    !
+    ! * z: rpe_var
+    !     An `rpe_var` instance representing the input literal at the given
+    !     precision.
+    !
+        REAL(KIND=RPE_REAL_KIND), INTENT(IN) :: x
+        INTEGER, OPTIONAL,        INTENT(IN) :: n
+        TYPE(rpe_var) :: z
+        IF (PRESENT(n)) THEN
+            z%sbits = n
+        END IF
+        z = x
+    END FUNCTION rpe_literal_real
+
+    FUNCTION rpe_literal_alternate (x, n) RESULT (z)
+    ! Create an `rpe_var` instance from a real literal.
+    !
+    ! Arguments:
+    !
+    ! * x: real(kind=RPE_ALTERNATE_KIND) [input]
+    !     The literal to transform to a reduced precision `rpe_var` instance.
+    !
+    ! * n: integer [input, optional]
+    !     The number of bits in the significand of the resulting reduced
+    !     precision number. If not specified then the result will have the
+    !     default precision.
+    !
+    ! Returns:
+    !
+    ! * z: rpe_var
+    !     An `rpe_var` instance representing the input literal at the given
+    !     precision.
+    !
+        REAL(KIND=RPE_ALTERNATE_KIND),           INTENT(IN) :: x
+        INTEGER,                       OPTIONAL, INTENT(IN) :: n
+        TYPE(rpe_var) :: z
+        IF (PRESENT(n)) THEN
+            z%sbits = n
+        END IF
+        z = x
+    END FUNCTION rpe_literal_alternate
+
+    FUNCTION rpe_literal_integer (x, n) RESULT (z)
+    ! Create an `rpe_var` instance from an integer literal.
+    !
+    ! Arguments:
+    !
+    ! * x: integer [input]
+    !     The literal to transform to a reduced precision `rpe_var` instance.
+    !
+    ! * n: integer [input, optional]
+    !     The number of bits in the significand of the resulting reduced
+    !     precision number. If not specified then the result will have the
+    !     default precision.
+    !
+    ! Returns:
+    !
+    ! * z: rpe_var
+    !     An `rpe_var` instance representing the input literal at the given
+    !     precision.
+    !
+        INTEGER,           INTENT(IN) :: x
+        INTEGER, OPTIONAL, INTENT(IN) :: n
+        TYPE(rpe_var) :: z
+        IF (PRESENT(n)) THEN
+            z%sbits = n
+        END IF
+        z = x
+    END FUNCTION rpe_literal_integer
+
+    FUNCTION rpe_literal_long (x, n) RESULT (z)
+    ! Create an `rpe_var` instance from a long integer literal.
+    !
+    ! Arguments:
+    !
+    ! * x: integer(KIND=8) [input]
+    !     The literal to transform to a reduced precision `rpe_var` instance.
+    !
+    ! * n: integer [input, optional]
+    !     The number of bits in the significand of the resulting reduced
+    !     precision number. If not specified then the result will have the
+    !     default precision.
+    !
+    ! Returns:
+    !
+    ! * z: rpe_var
+    !     An `rpe_var` instance representing the input literal at the given
+    !     precision.
+    !
+        INTEGER(KIND=8),           INTENT(IN) :: x
+        INTEGER,         OPTIONAL, INTENT(IN) :: n
+        TYPE(rpe_var) :: z
+        IF (PRESENT(n)) THEN
+            z%sbits = n
+        END IF
+        z = x
+    END FUNCTION rpe_literal_long
+
 
 !-----------------------------------------------------------------------
 ! Overloaded assignment definitions:

--- a/test/integration/lorenz63/l63_reduced_precision.f90
+++ b/test/integration/lorenz63/l63_reduced_precision.f90
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -20,32 +20,27 @@ PROGRAM lorenz63
     USE cliargs_mod, ONLY : cliargs
 
     IMPLICIT NONE
-    
+
     ! Time-stepping parameters.
     REAL(KIND=RPE_REAL_KIND) :: t
     REAL(KIND=RPE_REAL_KIND) :: time_start = 0
     REAL(KIND=RPE_REAL_KIND) :: time_stop = 5
     REAL(KIND=RPE_REAL_KIND) :: dt = 0.01
-    
+
     ! Lorenz 63 system parameters.
     TYPE(rpe_var) :: sigma
     TYPE(rpe_var) :: rho
     TYPE(rpe_var) :: beta
-    
+
     ! Array to store the 3d coordinate of the current system state.
     TYPE(rpe_var), DIMENSION(3) :: x
 
     ! Runge-Kutta parameters.
     TYPE(rpe_var), DIMENSION(3) :: k1, k2, k3, k4
     TYPE(rpe_var), DIMENSION(3) :: x2, x3, x4, xd
-    TYPE(rpe_var) :: half, six
 
     ! Handle command line arguments.
     CALL cliargs (RPE_ACTIVE, RPE_DEFAULT_SBITS, RPE_IEEE_HALF)
-
-    ! Special reduced-precision constants.
-    half = 0.5_RPE_REAL_KIND
-    six = 6.0_RPE_REAL_KIND
 
     ! Set the model parameters.
     sigma = 10
@@ -55,18 +50,18 @@ PROGRAM lorenz63
     ! Set the initial state.
     t = time_start
     x = (/ 1.508870_RPE_REAL_KIND, -1.531271_RPE_REAL_KIND, 25.46091_RPE_REAL_KIND /)
-    
+
     ! Loop over time evaluating the model state (x).
     WRITE (*, '(F19.15, "    ", F19.15, "    ", F19.15)') x%val
     DO WHILE (t <= time_stop)
         k1 = f(x, sigma, rho, beta)
-        x2 = x + half * dt * k1
+        x2 = x + rpe_literal(0.5) * dt * k1
         k2 = f(x2, sigma, rho, beta)
-        x3 = x + half * dt * k2
+        x3 = x + rpe_literal(0.5) * dt * k2
         k3 = f(x3, sigma, rho, beta)
         x4 = x + dt * k3
         k4 = f(x4, sigma, rho, beta)
-        x = x + dt * (k1 + 2 * (k2 + k3) + k4) / six
+        x = x + dt * (k1 + 2 * (k2 + k3) + k4) / rpe_literal(6.)
         t = t + dt
         WRITE (*, '(F19.15, "    ", F19.15, "    ", F19.15)') x%val
     END DO

--- a/test/unit/common/suite_common.f90
+++ b/test/unit/common/suite_common.f90
@@ -130,7 +130,7 @@ MODULE suite_common
     
     REAL(KIND=RPE_ALTERNATE_KIND), PARAMETER :: utest32 = z'404ccccd'
     REAL(KIND=RPE_REAL_KIND),      PARAMETER :: utest32_64 = z'40099999A0000000'
-    REAL(KIND=RPE_ALTERNATE_KIND), PARAMETER, DIMENSION(22) :: utest32_t = (/ &
+    REAL(KIND=RPE_ALTERNATE_KIND), PARAMETER, DIMENSION(23) :: utest32_t = (/ &
         REAL(z'40400000', RPE_ALTERNATE_KIND), & ! 1
         REAL(z'40400000', RPE_ALTERNATE_KIND), & ! 2
         REAL(z'40500000', RPE_ALTERNATE_KIND), & ! 3
@@ -143,8 +143,8 @@ MODULE suite_common
         REAL(z'404cc000', RPE_ALTERNATE_KIND), & ! 10
         REAL(z'404cd000', RPE_ALTERNATE_KIND), & ! 11
         REAL(z'404cd000', RPE_ALTERNATE_KIND), & ! 12
-        REAL(z'404cc000', RPE_ALTERNATE_KIND), & ! 13
-        REAL(z'404cc000', RPE_ALTERNATE_KIND), & ! 14
+        REAL(z'404ccc00', RPE_ALTERNATE_KIND), & ! 13
+        REAL(z'404ccc00', RPE_ALTERNATE_KIND), & ! 14
         REAL(z'404ccd00', RPE_ALTERNATE_KIND), & ! 15
         REAL(z'404ccd00', RPE_ALTERNATE_KIND), & ! 16
         REAL(z'404cccc0', RPE_ALTERNATE_KIND), & ! 17
@@ -152,7 +152,8 @@ MODULE suite_common
         REAL(z'404cccd0', RPE_ALTERNATE_KIND), & ! 19
         REAL(z'404cccd0', RPE_ALTERNATE_KIND), & ! 20
         REAL(z'404ccccc', RPE_ALTERNATE_KIND), & ! 21
-        REAL(z'404cccce', RPE_ALTERNATE_KIND)  & ! 22
+        REAL(z'404cccce', RPE_ALTERNATE_KIND), & ! 22
+        REAL(z'404ccccd', RPE_ALTERNATE_KIND)  & ! 23
     /)
 
 CONTAINS

--- a/test/unit/types/test_rpe_var.pf
+++ b/test/unit/types/test_rpe_var.pf
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -16,40 +16,209 @@ MODULE test_rpe_var
 ! Tests for the `rpe_var` type.
 !
     USE pfunit_mod
-    USE suite_common, ONLY : utest64_t, utest64
+    USE suite_common, ONLY : utest64_t, utest64, utest32, utest32_t
     USE rp_emulator
     IMPLICIT NONE
-    
+
+    @TESTCASE
+    TYPE, EXTENDS(TestCase) :: EmulatorTest
+        LOGICAL :: rpe_active
+        INTEGER :: rpe_default_sbits
+        LOGICAL :: rpe_ieee_half
+        LOGICAL :: rpe_ieee_rounding
+    CONTAINS
+        procedure :: setUp
+        procedure :: tearDown
+    END TYPE EmulatorTest
+
 CONTAINS
 
+    SUBROUTINE setUp (this)
+        CLASS(EmulatorTest), INTENT(INOUT) :: this
+        this%rpe_active = RPE_ACTIVE
+        this%rpe_default_sbits = RPE_DEFAULT_SBITS
+        this%rpe_ieee_half = RPE_IEEE_HALF
+        this%rpe_ieee_rounding = RPE_IEEE_ROUNDING
+    END SUBROUTINE setUp
+
+    SUBROUTINE tearDown (this)
+        CLASS(EmulatorTest), INTENT(INOUT) :: this
+        RPE_ACTIVE = this%rpe_active
+        RPE_DEFAULT_SBITS = this%rpe_default_sbits
+        RPE_IEEE_HALF = this%rpe_ieee_half
+        RPE_IEEE_ROUNDING = this%rpe_ieee_rounding
+    END SUBROUTINE tearDown
+
     @TEST
-    SUBROUTINE test_rpe_var_assign_reduce_default ()
+    SUBROUTINE test_rpe_var_assign_reduce_default (context)
     ! Verify that the precision of a value assigned to an `rpe_var`
     ! instance is reduced to the default number of bits by the
     ! assignment operator when no precision level has been set.
     !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: reduced
-        
+
         reduced = utest64
         @ASSERTEQUAL(reduced%val, utest64_t(23))
-        
+
     END SUBROUTINE test_rpe_var_assign_reduce_default
-        
+
     @TEST
-    SUBROUTINE test_rpe_var_assign_reduce_specified ()
+    SUBROUTINE test_rpe_var_assign_reduce_specified (context)
     ! Verify that the precision of a value assigned to an `rpe_var`
     ! instance is reduced to the instance's specified number of bits by
     ! the assignment operator.
     !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: reduced
         INTEGER       :: nbits
-        
+
         DO nbits = 1, 23
             reduced%sbits = nbits
             reduced = utest64
             @ASSERTEQUAL(reduced%val, utest64_t(nbits))
         END DO
-        
+
     END SUBROUTINE test_rpe_var_assign_reduce_specified
+
+    @TEST
+    SUBROUTINE test_rpe_literal_real_64bit_explicit (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: nbits
+
+        DO nbits = 1, 23
+            reduced = rpe_literal(utest64, nbits)
+            @ASSERTEQUAL(reduced%val, utest64_t(nbits))
+        END DO
+
+    END SUBROUTINE test_rpe_literal_real_64bit_explicit
+
+    @TEST
+    SUBROUTINE test_rpe_literal_real_64bit_defaults (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: nbits
+
+        DO nbits = 1, 23
+            RPE_DEFAULT_SBITS = nbits
+            reduced = rpe_literal(utest64)
+            @ASSERTEQUAL(reduced%val, utest64_t(nbits))
+        END DO
+
+    END SUBROUTINE test_rpe_literal_real_64bit_defaults
+
+    @TEST
+    SUBROUTINE test_rpe_literal_real_32bit_explicit (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: nbits
+
+        DO nbits = 1, 23
+            reduced = rpe_literal(utest32, nbits)
+            @ASSERTEQUAL(utest32_t(nbits), reduced%val)
+        END DO
+
+    END SUBROUTINE test_rpe_literal_real_32bit_explicit
+
+    @TEST
+    SUBROUTINE test_rpe_literal_real_32bit_defaults (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: nbits
+
+        DO nbits = 1, 23
+            RPE_DEFAULT_SBITS = nbits
+            reduced = rpe_literal(utest32)
+            @ASSERTEQUAL(utest32_t(nbits), reduced%val)
+        END DO
+
+    END SUBROUTINE test_rpe_literal_real_32bit_defaults
+
+    @TEST
+    SUBROUTINE test_rpe_literal_integer_explicit (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: exact_value, inexact_value
+
+        exact_value = 1024  ! exact at 23-bits (default)
+        reduced = rpe_literal(exact_value)
+        @ASSERTEQUAL(reduced%val, REAL(exact_value, RPE_REAL_KIND))
+        inexact_value = 10241024 ! = 10256384 at 8-bits
+        reduced = rpe_literal(inexact_value, 8)
+        @ASSERTEQUAL(reduced%val, REAL(10256384, RPE_REAL_KIND))
+
+    END SUBROUTINE test_rpe_literal_integer_explicit
+
+    @TEST
+    SUBROUTINE test_rpe_literal_integer_defaults (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: exact_value, inexact_value
+
+        exact_value = 1024  ! exact at 23-bits (default)
+        reduced = rpe_literal(exact_value)
+        @ASSERTEQUAL(reduced%val, REAL(exact_value, RPE_REAL_KIND))
+        inexact_value = 10241024 ! = 10256384 at 8-bits
+        RPE_DEFAULT_SBITS = 8
+        reduced = rpe_literal(inexact_value)
+        @ASSERTEQUAL(reduced%val, REAL(10256384, RPE_REAL_KIND))
+
+    END SUBROUTINE test_rpe_literal_integer_defaults
+
+    @TEST
+    SUBROUTINE test_rpe_literal_long_explicit (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var)   :: reduced
+        INTEGER(KIND=8) :: exact_value, inexact_value
+
+        exact_value = 1024  ! exact at 23-bits (default)
+        reduced = rpe_literal(exact_value)
+        @ASSERTEQUAL(reduced%val, REAL(exact_value, RPE_REAL_KIND))
+        inexact_value = 10241024 ! = 10256384 at 8-bits
+        reduced = rpe_literal(inexact_value, 8)
+        @ASSERTEQUAL(reduced%val, REAL(10256384, RPE_REAL_KIND))
+
+    END SUBROUTINE test_rpe_literal_long_explicit
+
+    @TEST
+    SUBROUTINE test_rpe_literal_long_defaults (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var)   :: reduced
+        INTEGER(KIND=8) :: exact_value, inexact_value
+
+        exact_value = 1024  ! exact at 23-bits (default)
+        reduced = rpe_literal(exact_value)
+        @ASSERTEQUAL(reduced%val, REAL(exact_value, RPE_REAL_KIND))
+        inexact_value = 10241024 ! = 10256384 at 8-bits
+        RPE_DEFAULT_SBITS = 8
+        reduced = rpe_literal(inexact_value)
+        @ASSERTEQUAL(reduced%val, REAL(10256384, RPE_REAL_KIND))
+
+    END SUBROUTINE test_rpe_literal_long_defaults
 
 END MODULE test_rpe_var


### PR DESCRIPTION
Sometimes you want to perform a reduced-precision calculation that involves a real literal constant (something not defined as a variable), and currently this could cause the precision of intermediate steps to be increased. 

A simple example:

```fortran
type(rpe_var) :: a, b, r

! Work with 10 bits precision by default.
RPE_DEFAULT_SBITS = 10

a = 1.234
b = 5.678
r = 0.9 * a + b
```

Because of casting between mixed precision types the last calculation will be evaluated retaining 23 bits in the significand (the intermediate `tmp1 = 0.9 * a` is stored at 23 bits because `0.9` is a real number with a 23-bit significand, and `tmp1 + b` is also evaluated with 23 bits of precision because `tmp1` has 23 bits in its significand).

This PR adds a new interface `rpe_var` which is a quick and convenient way of generating one-shot reduced-precision variables from a literal. Using it the example above would become:

```fortran
type(rpe_var) :: a, b, r

! Work with 10 bits precision by default.
RPE_DEFAULT_SBITS = 10

a = 1.234
b = 5.678
r = rpe_literal(0.9) * a + b
```

The function `rpe_literal(value)` call takes a literal input and converts it to an `rpe_var` instance with the default number of significand bits, in the example above 10 (i.e. the value is truncated to 10-bits in the significand and returned as an `rpe_type`). Optionally you can pass a number of bits as in:

```fortran
type(rpe_var) :: a, b, r

! Work with 10 bits precision by default.
RPE_DEFAULT_SBITS = 10

a = 1.234
b = 5.678
r = rpe_literal(0.9, 5) * a + b
```
which would only use 5 significand bits to represent the literal `0.9`.

Thoughts and feedback on both usefulness and implementation welcome.
