### PR TITLE
Full IEEE rounding

### DIFF
--- a/doc/api/rp_emulator.rst
+++ b/doc/api/rp_emulator.rst
@@ -72,6 +72,19 @@ Variables
    This option only affects the emulation when emulating a 10-bit significand.
 
 
+.. f:variable:: RPE_IEEE_ROUNDING
+   :type: LOGICAL
+   :attrs: default=.FALSE.
+
+    Logical value determining if full IEEE 754 rounding rules should be used.
+    If ``.TRUE.`` then a *"round to nearest, tie to even"* rounding scheme will be used, which proceeds as normal rounding to the nearest representable number, except in the special case where a number is halfway between two representations where it will be rounded so that the least significant bit of the results is a zero.
+    If ``.FALSE.`` then then rounding scheme rounds numbers halfway between two representations to the representation with larger absolute value.
+
+    .. note::
+
+       It is recommended to set this option to ``.TRUE.``. Currently the default is ``.FALSE.`` for backwards compatibility reasons. In a future release the bahaviour of the ``.TRUE.`` setting will become the default (and possibly only) option.
+
+
 Parameters
 ==========
 

--- a/src/rp_emulator.F90
+++ b/src/rp_emulator.F90
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.

--- a/src/rp_emulator.F90
+++ b/src/rp_emulator.F90
@@ -51,6 +51,9 @@ MODULE rp_emulator
     !: be used when operating on values with 10 bits in the significand.
     LOGICAL, PUBLIC :: RPE_IEEE_HALF = .FALSE.
 
+    !: Logical flag for determining if IEEE rounding rules should be used.
+    LOGICAL, PUBLIC :: RPE_IEEE_ROUNDING = .FALSE.
+
     !: An internal value used to represent the case where a reduced-precision
     !: number has no specified precision yet.
     INTEGER, PARAMETER, PRIVATE :: RPE_SBITS_UNSPECIFIED = -1
@@ -182,9 +185,8 @@ CONTAINS
             ! Copy the double-precision bit representation of the input
             ! into an integer so it can be manipulated:
             bits = TRANSFER(x, bits)
-            IF (BTEST(bits, truncation_bit)) THEN
-                ! If the bit at which truncation occurs is set then
-                ! make sure the truncation rounds the number up:
+            IF (do_ieee_rounding(bits, truncation_bit)) THEN
+                ! Round before truncation if required by IEEE rules.
                 bits = bits + two ** truncation_bit
             END IF
             ! Move rounding_bit + 1 bits from the number zero (all bits
@@ -200,6 +202,64 @@ CONTAINS
             t = x
         END IF
     END FUNCTION truncate_significand
+
+    ELEMENTAL FUNCTION do_ieee_rounding (bits, truncation_bit)
+    ! Determine if rounding is required before truncation according to
+    ! IEEE 754 rounding rules.
+    !
+    ! Generally rounding is a round-to-nearest scheme, with a special
+    ! case for values halfway between two representations which in which
+    ! case a round-to-even scheme is used to ensure the last bit of the
+    ! truncated value is a '0'.
+    !
+    ! Arguments:
+    !
+    ! * bits: integer(kind=8) [input]
+    !     The bit-representation of a floating-point number (64 bits)
+    !     stored in an 8-byte integer.
+    !
+    ! * truncation_bit: integer [input]
+    !     The index of the most significant bit to be lost by a
+    !     truncation. Indices start at 0 for the least significant bit.
+    !
+    ! Returns:
+    !
+    ! * do_ieee_rounding: logical
+    !     Either `.TRUE.`, indicating that the floating-point number
+    !     represented by `bits` should be rounded before truncation,
+    !     or `.FALSE.` indicating that no rounding is required.
+    !
+        INTEGER(KIND=8), INTENT(IN) :: bits
+        INTEGER,         INTENT(IN) :: truncation_bit
+        LOGICAL :: do_ieee_rounding
+        LOGICAL :: is_halfway, candidate
+        INTEGER :: bit
+        candidate = BTEST(bits, truncation_bit)
+        IF (candidate .AND. RPE_IEEE_ROUNDING) THEN
+            ! Most significant bit to be truncated is set ('1'), check if
+            ! the remaining bits to be truncated are all '0', if so this
+            ! number is halfway between two representations.
+            is_halfway = .TRUE.
+            DO bit = 0, truncation_bit - 1
+                IF (BTEST(bits, bit)) THEN
+                    is_halfway = .FALSE.
+                    EXIT
+                END IF
+            END DO
+            ! If the number is halfway between two representations and the
+            ! least significant bit of the result is not set ('0') then no
+            ! rounding is required.
+            IF (is_halfway .AND. (.NOT. BTEST(bits, truncation_bit + 1))) THEN
+                do_ieee_rounding = .FALSE.
+            ELSE
+                do_ieee_rounding = .TRUE.
+            END IF
+        ELSE IF (candidate) THEN
+            do_ieee_rounding = .TRUE.
+        ELSE
+            do_ieee_rounding = .FALSE.
+        END IF
+    END FUNCTION do_ieee_rounding
 
     ELEMENTAL FUNCTION adjust_ieee_half (x) RESULT (y)
     ! Adjust a floating-point number according to the IEEE half-precision

--- a/test/unit/common/suite_common.f90
+++ b/test/unit/common/suite_common.f90
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.

--- a/test/unit/common/suite_common.f90
+++ b/test/unit/common/suite_common.f90
@@ -56,6 +56,77 @@ MODULE suite_common
         REAL(z'408C86A780000000', RPE_REAL_KIND), & ! 22
         REAL(z'408C86A760000000', RPE_REAL_KIND)  & ! 23
     /)
+
+    ! A double precision floating-point number used for testing reduction
+    ! of precision. This particular choice includes an exponent incursion
+    ! at 1 bit of precision and a case where extra IEEE rounding rules will
+    ! be invoked to avoid rounding bias.. The number has the following
+    ! representations:
+    !
+    !  hexadecimal: 0x408C86A761308B44
+    !  binary: 0100000010001100100001101010011101100001001100001000101101000100
+    !  floating-point: 912.8317283432484
+    !
+    REAL(KIND=RPE_REAL_KIND), PARAMETER :: utest64_ieee = z'408c86a761308b44'
+    !
+    ! An array storing the same number at significand precisions from 1 to 23
+    ! bits. These truncated representations are rounded correctly (including
+    ! IEEE 'round to even' rule).
+    !
+    REAL(KIND=RPE_REAL_KIND), PARAMETER, DIMENSION(52) :: utest64_ieee_t = (/ &
+        REAL(z'4090000000000000', RPE_REAL_KIND), & ! 1
+        REAL(z'408C000000000000', RPE_REAL_KIND), & ! 2
+        REAL(z'408C000000000000', RPE_REAL_KIND), & ! 3
+        REAL(z'408D000000000000', RPE_REAL_KIND), & ! 4
+        REAL(z'408C800000000000', RPE_REAL_KIND), & ! 5
+        REAL(z'408C800000000000', RPE_REAL_KIND), & ! 6
+        REAL(z'408C800000000000', RPE_REAL_KIND), & ! 7
+        REAL(z'408C800000000000', RPE_REAL_KIND), & ! 8
+        REAL(z'408C880000000000', RPE_REAL_KIND), & ! 9
+        REAL(z'408C880000000000', RPE_REAL_KIND), & ! 10
+        REAL(z'408C860000000000', RPE_REAL_KIND), & ! 11
+        REAL(z'408C870000000000', RPE_REAL_KIND), & ! 12
+        REAL(z'408C868000000000', RPE_REAL_KIND), & ! 13
+        REAL(z'408C86C000000000', RPE_REAL_KIND), & ! 14
+        REAL(z'408C86A000000000', RPE_REAL_KIND), & ! 15
+        REAL(z'408C86A000000000', RPE_REAL_KIND), & ! 16
+        REAL(z'408C86A800000000', RPE_REAL_KIND), & ! 17
+        REAL(z'408C86A800000000', RPE_REAL_KIND), & ! 18
+        REAL(z'408C86A800000000', RPE_REAL_KIND), & ! 19
+        REAL(z'408C86A700000000', RPE_REAL_KIND), & ! 20
+        REAL(z'408C86A780000000', RPE_REAL_KIND), & ! 21
+        REAL(z'408C86A780000000', RPE_REAL_KIND), & ! 22
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 23
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 24
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 25
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 26
+        REAL(z'408C86A762000000', RPE_REAL_KIND), & ! 27
+        REAL(z'408C86A761000000', RPE_REAL_KIND), & ! 28
+        REAL(z'408C86A761000000', RPE_REAL_KIND), & ! 29
+        REAL(z'408C86A761400000', RPE_REAL_KIND), & ! 30
+        REAL(z'408C86A761400000', RPE_REAL_KIND), & ! 31
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 32
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 33
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 34
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 35
+        REAL(z'408C86A761310000', RPE_REAL_KIND), & ! 36
+        REAL(z'408C86A761308000', RPE_REAL_KIND), & ! 37
+        REAL(z'408C86A761308000', RPE_REAL_KIND), & ! 38
+        REAL(z'408C86A761308000', RPE_REAL_KIND), & ! 39
+        REAL(z'408C86A761309000', RPE_REAL_KIND), & ! 40
+        REAL(z'408C86A761308800', RPE_REAL_KIND), & ! 41
+        REAL(z'408C86A761308C00', RPE_REAL_KIND), & ! 42
+        REAL(z'408C86A761308C00', RPE_REAL_KIND), & ! 43
+        REAL(z'408C86A761308B00', RPE_REAL_KIND), & ! 44
+        REAL(z'408C86A761308B80', RPE_REAL_KIND), & ! 45
+        REAL(z'408C86A761308B40', RPE_REAL_KIND), & ! 46
+        REAL(z'408C86A761308B40', RPE_REAL_KIND), & ! 47
+        REAL(z'408C86A761308B40', RPE_REAL_KIND), & ! 48
+        REAL(z'408C86A761308B40', RPE_REAL_KIND), & ! 49
+        REAL(z'408C86A761308B44', RPE_REAL_KIND), & ! 50
+        REAL(z'408C86A761308B44', RPE_REAL_KIND), & ! 51
+        REAL(z'408C86A761308B44', RPE_REAL_KIND)  & ! 52
+    /)
     
     REAL(KIND=RPE_ALTERNATE_KIND), PARAMETER :: utest32 = z'404ccccd'
     REAL(KIND=RPE_REAL_KIND),      PARAMETER :: utest32_64 = z'40099999A0000000'

--- a/test/unit/core/test_apply_truncation.pf
+++ b/test/unit/core/test_apply_truncation.pf
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.

--- a/test/unit/core/test_apply_truncation.pf
+++ b/test/unit/core/test_apply_truncation.pf
@@ -16,7 +16,9 @@ MODULE test_apply_truncation
 ! Tests for the apply_truncation subroutine
 !
     USE pfunit_mod
-    USE suite_common, ONLY : utest64, min_significand_bits
+    USE suite_common, ONLY : utest64, &
+                             utest64_ieee, utest64_ieee_t, &
+                             min_significand_bits
     USE rp_emulator
     IMPLICIT NONE
 
@@ -25,6 +27,7 @@ MODULE test_apply_truncation
         LOGICAL :: rpe_active
         INTEGER :: rpe_default_sbits
         LOGICAL :: rpe_ieee_half
+        LOGICAL :: rpe_ieee_rounding
     CONTAINS
         procedure :: setUp
         procedure :: tearDown
@@ -37,6 +40,7 @@ CONTAINS
         this%rpe_active = RPE_ACTIVE
         this%rpe_default_sbits = RPE_DEFAULT_SBITS
         this%rpe_ieee_half = RPE_IEEE_HALF
+        this%rpe_ieee_rounding = RPE_IEEE_ROUNDING
     END SUBROUTINE setUp
 
     SUBROUTINE tearDown (this)
@@ -44,6 +48,7 @@ CONTAINS
         RPE_ACTIVE = this%rpe_active
         RPE_DEFAULT_SBITS = this%rpe_default_sbits
         RPE_IEEE_HALF = this%rpe_ieee_half
+        RPE_IEEE_ROUNDING = this%rpe_ieee_rounding
     END SUBROUTINE tearDown
 
     @TEST
@@ -109,5 +114,22 @@ CONTAINS
         @ASSERTEQUAL(-limit + 2 * delta, reduced%val)
         @ASSERTLESSTHANOREQUAL(min_significand_bits(reduced%val), 10)
     END SUBROUTINE test_apply_truncation_ieee_half_subnormal
+
+    @TEST
+    SUBROUTINE test_apply_truncation_ieee_rounding (context)
+    ! Test that IEEE rounding functions correctly.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER :: nbits
+
+        RPE_IEEE_ROUNDING = .TRUE.
+
+        DO nbits = 1, 52
+            reduced%sbits = nbits
+            reduced = utest64_ieee
+            @ASSERTEQUAL(reduced%val, utest64_ieee_t(nbits))
+        END DO
+    END SUBROUTINE test_apply_truncation_ieee_rounding
 
 END MODULE test_apply_truncation


### PR DESCRIPTION
The current implementation of rounding is not fully IEEE compliant. This PR introduces a (currently optional) extension to allow full IEEE compliant rounding to be used.

The extended rounding scheme is a *"Round to nearest, tie to even"* rounding scheme which proceeds as normal, rounding to the nearest representable number, except in the special case where a number is halfway between two representations where it will be rounded so that the least significant bit of the results is a zero.