### PR TITLE
Improve osx compatibility.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # which can be compiled into the emulator library and associated module.
 #
 
-# Copyright 2015 Andrew Dawson, Peter Dueben
+# Copyright 2015-2016 Andrew Dawson, Peter Dueben
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ genincdir = src/include
 geninc = $(wildcard $(genincdir)/*.i $(genincdir)/*.f90)
 
 # The processed source file:
-unified_source = src/rp_emulator.f90
+unified_source = src/processed/rp_emulator.f90
 
 # The module and library resulting from compiling the processed source:
 object = src/rp_emulator.o
@@ -68,6 +68,7 @@ $(libshared): $(object)
 
 # Generate the full source listing using the C preprocessor:
 $(unified_source): $(src) $(geninc)
+	mkdir -p $(dir $(unified_source))
 	cpp -I$(genincdir) $(src) | sed '/^#/d' > $(unified_source)
 
 # Test the built library.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ of the Makefile:
 
     make source
 
-This will generate the file `src/rp_emulator.f90` (note the lower case
-extension) which can be integrated into the source of other projects.
+This will generate the file `src/processed/rp_emulator.f90` which can be
+integrated into the source of other projects.
 
 
 ## Documentation

--- a/doc/userguide/build_install.rst
+++ b/doc/userguide/build_install.rst
@@ -53,8 +53,7 @@ of the Makefile::
 
     make source
 
-This will generate the file ``src/rp_emulator.f90`` (note the lower case
-extension) which can be integrated into the source of other projects.
+This will generate the file ``src/processed/rp_emulator.f90`` which can be integrated into the source of other projects.
 
 
 Integration

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,3 @@
 # The generated source code will be written in this directory:
-rp_emulator.f90
+processed/
+processed/rp_emulator.f90


### PR DESCRIPTION
OSX uses a case-insensitive filesystem by default, which causes a problem when building and particularly when cleaning the source, since we have two files in the same directory with the same name when viewed in a case-insensitive context.

If you build on osx with `make source` the preprocessed source will replace the original `rp_emulator.F90` file. Worse, if you do `make clean` it will remove both `rp_emulator.f90` *and* `rp_emulator.F90`, thus deleting the core of the emulator!

The simple solution is to move the preprocessed source file `rp_emulator.f90` (the output of `make source`) to its own directory, and document this change. After this I don't believe there are any name conflicts.