### PR TITLE
Backport rpe_literal to v3.x from master

### DIFF
--- a/doc/api/rp_emulator.rst
+++ b/doc/api/rp_emulator.rst
@@ -45,6 +45,51 @@ User-callable procedures
    :param rpe_shadow shadow [INOUT]: The :f:type:`rpe_shadow` instance to initialize.
    :param REAL target [KIND=RPE_REAL_KIND,IN]: A floating-point variable to shadow. This must be a variable defined within the scope of the :f:func:`init_shadow` call otherwise invalid memory references will occur.
 
+
+.. f:function:: rpe_literal (x, n)
+
+   Construct an :f:type:`rpe_var` instance from a value.
+   Optionally a number of significand bits used to store the value may be given.
+   The value will be truncated before storage.
+   A typical usage of this constructor is to support reduced precision literal values without having to declare extra variables:
+
+   .. code-block:: fortran
+
+      type(rpe_var) :: a, b, c, d, e
+
+      RPE_DEFAULT_SBITS = 10
+
+      ! variables a, b and c have a 10-bit significands:
+      a = 5.00
+      b = 7.23
+      c = 21.12
+
+      ! The literals 7.29e-5, 3.14 and 18.17 have full precision
+      ! (a 23-bit significand):
+      d = 7.29e-5 * a + 3.14 * b + 18.17 * c  ! d = 406.5
+
+      ! The literals are replaced by rpe_var instances with 10-bit significands:
+      e = rpe_literal(7.29e-5) * a + rpe_literal(3.14) * b + rpe_literal(18.17) * c  ! e = 406.75
+
+   :param x [IN]: A real or integer value to store in the resulting :f:type:`rpe_var` instance.
+   :param integer n [IN,OPTIONAL]: An optional number of significand bits used to represent the number, equivalent of setting the :f:var:`sbits` attribute of an :f:type:`rpe_var` instance. If not specified then the resulting :f:type:`rpe_var` will use the default precision specified by :f:var:`RPE_DEFAULT_SBITS`.
+
+   .. note::
+
+      If you use this to create an :f:type:`rpe_var` instance and then assign the result to another instance, only the value will be copied:
+
+      .. code-block:: fortran
+
+         ! An rpe_var instance with a 13 bit significand:
+         type(rpe_var) :: a
+         a%sbits = 13
+
+         ! Construct an rpe_type instance with a 15-bit significand and assign to a,
+         ! the value will be truncated to 13 bits and the variable a will continue
+         ! to store only 13 significand bits.
+         a = rpe_literal(1.23456789, 15)
+
+
 .. f:subroutine:: apply_truncation (rpe)
    :attrs: elemental
 

--- a/rawsrc/rp_emulator.F90
+++ b/rawsrc/rp_emulator.F90
@@ -151,6 +151,16 @@ MODULE rp_emulator
         MODULE PROCEDURE init_shadow_v4d
     END INTERFACE
 
+    ! Create a public interface for constructing literal reduced
+    ! precision values (rpe_var instances).
+    PUBLIC rpe_literal
+    INTERFACE rpe_literal
+        MODULE PROCEDURE rpe_literal_real
+        MODULE PROCEDURE rpe_literal_alternate
+        MODULE PROCEDURE rpe_literal_integer
+        MODULE PROCEDURE rpe_literal_long
+    END INTERFACE
+
     ! Make the core emulator routines importable.
     PUBLIC :: apply_truncation, significand_bits
 
@@ -624,6 +634,119 @@ CONTAINS
             z = 0
         END SELECT
     END FUNCTION significand_bits
+
+    FUNCTION rpe_literal_real (x, n) RESULT (z)
+    ! Create an `rpe_var` instance from a real literal.
+    !
+    ! Arguments:
+    !
+    ! * x: real(kind=RPE_REAL_KIND) [input]
+    !     The literal to transform to a reduced precision `rpe_var` instance.
+    !
+    ! * n: integer [input, optional]
+    !     The number of bits in the significand of the resulting reduced
+    !     precision number. If not specified then the result will have the
+    !     default precision.
+    !
+    ! Returns:
+    !
+    ! * z: rpe_var
+    !     An `rpe_var` instance representing the input literal at the given
+    !     precision.
+    !
+        REAL(KIND=RPE_REAL_KIND), INTENT(IN) :: x
+        INTEGER, OPTIONAL,        INTENT(IN) :: n
+        TYPE(rpe_var) :: z
+        IF (PRESENT(n)) THEN
+            z%sbits = n
+        END IF
+        z = x
+    END FUNCTION rpe_literal_real
+
+    FUNCTION rpe_literal_alternate (x, n) RESULT (z)
+    ! Create an `rpe_var` instance from a real literal.
+    !
+    ! Arguments:
+    !
+    ! * x: real(kind=RPE_ALTERNATE_KIND) [input]
+    !     The literal to transform to a reduced precision `rpe_var` instance.
+    !
+    ! * n: integer [input, optional]
+    !     The number of bits in the significand of the resulting reduced
+    !     precision number. If not specified then the result will have the
+    !     default precision.
+    !
+    ! Returns:
+    !
+    ! * z: rpe_var
+    !     An `rpe_var` instance representing the input literal at the given
+    !     precision.
+    !
+        REAL(KIND=RPE_ALTERNATE_KIND),           INTENT(IN) :: x
+        INTEGER,                       OPTIONAL, INTENT(IN) :: n
+        TYPE(rpe_var) :: z
+        IF (PRESENT(n)) THEN
+            z%sbits = n
+        END IF
+        z = x
+    END FUNCTION rpe_literal_alternate
+
+    FUNCTION rpe_literal_integer (x, n) RESULT (z)
+    ! Create an `rpe_var` instance from an integer literal.
+    !
+    ! Arguments:
+    !
+    ! * x: integer [input]
+    !     The literal to transform to a reduced precision `rpe_var` instance.
+    !
+    ! * n: integer [input, optional]
+    !     The number of bits in the significand of the resulting reduced
+    !     precision number. If not specified then the result will have the
+    !     default precision.
+    !
+    ! Returns:
+    !
+    ! * z: rpe_var
+    !     An `rpe_var` instance representing the input literal at the given
+    !     precision.
+    !
+        INTEGER,           INTENT(IN) :: x
+        INTEGER, OPTIONAL, INTENT(IN) :: n
+        TYPE(rpe_var) :: z
+        IF (PRESENT(n)) THEN
+            z%sbits = n
+        END IF
+        z = x
+    END FUNCTION rpe_literal_integer
+
+    FUNCTION rpe_literal_long (x, n) RESULT (z)
+    ! Create an `rpe_var` instance from a long integer literal.
+    !
+    ! Arguments:
+    !
+    ! * x: integer(KIND=8) [input]
+    !     The literal to transform to a reduced precision `rpe_var` instance.
+    !
+    ! * n: integer [input, optional]
+    !     The number of bits in the significand of the resulting reduced
+    !     precision number. If not specified then the result will have the
+    !     default precision.
+    !
+    ! Returns:
+    !
+    ! * z: rpe_var
+    !     An `rpe_var` instance representing the input literal at the given
+    !     precision.
+    !
+        INTEGER(KIND=8),           INTENT(IN) :: x
+        INTEGER,         OPTIONAL, INTENT(IN) :: n
+        TYPE(rpe_var) :: z
+        IF (PRESENT(n)) THEN
+            z%sbits = n
+        END IF
+        z = x
+    END FUNCTION rpe_literal_long
+
 
 !-----------------------------------------------------------------------
 ! Overloaded assignment definitions:

--- a/rawsrc/rp_emulator.F90
+++ b/rawsrc/rp_emulator.F90
@@ -441,7 +441,7 @@ CONTAINS
     ! Arguments:
     !
     ! * x: real(kind=RPE_DOUBLE_KIND) [input]
-    !     The doyuble precision number to truncate.
+    !     The double precision number to truncate.
     !
     ! * n: integer [input]
     !     The number of bits to truncate the significand to.
@@ -599,13 +599,13 @@ CONTAINS
     ! Arguments:
     !
     ! * x: class(*) [input]
-    !       A scalar input of any type.
+    !     A scalar input of any type.
     !
     ! Returns:
     !
     ! * z: integer [output]
-    !       The number of bits in the significand of the input floating-point
-    !       value, or 0 if the input was not a floating-point value.
+    !     The number of bits in the significand of the input floating-point
+    !     value, or 0 if the input was not a floating-point value.
     !
         CLASS(*), INTENT(IN) :: x
         INTEGER :: z

--- a/test/unit/common/suite_common.f90
+++ b/test/unit/common/suite_common.f90
@@ -130,7 +130,7 @@ MODULE suite_common
     
     REAL(KIND=RPE_ALTERNATE_KIND), PARAMETER :: utest32 = z'404ccccd'
     REAL(KIND=RPE_REAL_KIND),      PARAMETER :: utest32_64 = z'40099999A0000000'
-    REAL(KIND=RPE_ALTERNATE_KIND), PARAMETER, DIMENSION(22) :: utest32_t = (/ &
+    REAL(KIND=RPE_ALTERNATE_KIND), PARAMETER, DIMENSION(23) :: utest32_t = (/ &
         REAL(z'40400000', RPE_ALTERNATE_KIND), & ! 1
         REAL(z'40400000', RPE_ALTERNATE_KIND), & ! 2
         REAL(z'40500000', RPE_ALTERNATE_KIND), & ! 3
@@ -143,8 +143,8 @@ MODULE suite_common
         REAL(z'404cc000', RPE_ALTERNATE_KIND), & ! 10
         REAL(z'404cd000', RPE_ALTERNATE_KIND), & ! 11
         REAL(z'404cd000', RPE_ALTERNATE_KIND), & ! 12
-        REAL(z'404cc000', RPE_ALTERNATE_KIND), & ! 13
-        REAL(z'404cc000', RPE_ALTERNATE_KIND), & ! 14
+        REAL(z'404ccc00', RPE_ALTERNATE_KIND), & ! 13
+        REAL(z'404ccc00', RPE_ALTERNATE_KIND), & ! 14
         REAL(z'404ccd00', RPE_ALTERNATE_KIND), & ! 15
         REAL(z'404ccd00', RPE_ALTERNATE_KIND), & ! 16
         REAL(z'404cccc0', RPE_ALTERNATE_KIND), & ! 17
@@ -152,7 +152,8 @@ MODULE suite_common
         REAL(z'404cccd0', RPE_ALTERNATE_KIND), & ! 19
         REAL(z'404cccd0', RPE_ALTERNATE_KIND), & ! 20
         REAL(z'404ccccc', RPE_ALTERNATE_KIND), & ! 21
-        REAL(z'404cccce', RPE_ALTERNATE_KIND)  & ! 22
+        REAL(z'404cccce', RPE_ALTERNATE_KIND), & ! 22
+        REAL(z'404ccccd', RPE_ALTERNATE_KIND)  & ! 23
     /)
 
 CONTAINS

--- a/test/unit/types/test_rpe_var.pf
+++ b/test/unit/types/test_rpe_var.pf
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -16,40 +16,209 @@ MODULE test_rpe_var
 ! Tests for the `rpe_var` type.
 !
     USE pfunit_mod
-    USE suite_common, ONLY : utest64_t, utest64
+    USE suite_common, ONLY : utest64_t, utest64, utest32, utest32_t
     USE rp_emulator
     IMPLICIT NONE
-    
+
+    @TESTCASE
+    TYPE, EXTENDS(TestCase) :: EmulatorTest
+        LOGICAL :: rpe_active
+        INTEGER :: rpe_default_sbits
+        LOGICAL :: rpe_ieee_half
+        LOGICAL :: rpe_ieee_rounding
+    CONTAINS
+        procedure :: setUp
+        procedure :: tearDown
+    END TYPE EmulatorTest
+
 CONTAINS
 
+    SUBROUTINE setUp (this)
+        CLASS(EmulatorTest), INTENT(INOUT) :: this
+        this%rpe_active = RPE_ACTIVE
+        this%rpe_default_sbits = RPE_DEFAULT_SBITS
+        this%rpe_ieee_half = RPE_IEEE_HALF
+        this%rpe_ieee_rounding = RPE_IEEE_ROUNDING
+    END SUBROUTINE setUp
+
+    SUBROUTINE tearDown (this)
+        CLASS(EmulatorTest), INTENT(INOUT) :: this
+        RPE_ACTIVE = this%rpe_active
+        RPE_DEFAULT_SBITS = this%rpe_default_sbits
+        RPE_IEEE_HALF = this%rpe_ieee_half
+        RPE_IEEE_ROUNDING = this%rpe_ieee_rounding
+    END SUBROUTINE tearDown
+
     @TEST
-    SUBROUTINE test_rpe_var_assign_reduce_default ()
+    SUBROUTINE test_rpe_var_assign_reduce_default (context)
     ! Verify that the precision of a value assigned to an `rpe_var`
     ! instance is reduced to the default number of bits by the
     ! assignment operator when no precision level has been set.
     !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: reduced
-        
+
         reduced = utest64
         @ASSERTEQUAL(reduced%get_value(), utest64_t(23))
-        
+
     END SUBROUTINE test_rpe_var_assign_reduce_default
-        
+
     @TEST
-    SUBROUTINE test_rpe_var_assign_reduce_specified ()
+    SUBROUTINE test_rpe_var_assign_reduce_specified (context)
     ! Verify that the precision of a value assigned to an `rpe_var`
     ! instance is reduced to the instance's specified number of bits by
     ! the assignment operator.
     !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: reduced
         INTEGER       :: nbits
-        
+
         DO nbits = 1, 23
             reduced%sbits = nbits
             reduced = utest64
             @ASSERTEQUAL(reduced%get_value(), utest64_t(nbits))
         END DO
-        
+
     END SUBROUTINE test_rpe_var_assign_reduce_specified
+
+    @TEST
+    SUBROUTINE test_rpe_literal_real_64bit_explicit (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: nbits
+
+        DO nbits = 1, 23
+            reduced = rpe_literal(utest64, nbits)
+            @ASSERTEQUAL(reduced%get_value(), utest64_t(nbits))
+        END DO
+
+    END SUBROUTINE test_rpe_literal_real_64bit_explicit
+
+    @TEST
+    SUBROUTINE test_rpe_literal_real_64bit_defaults (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: nbits
+
+        DO nbits = 1, 23
+            RPE_DEFAULT_SBITS = nbits
+            reduced = rpe_literal(utest64)
+            @ASSERTEQUAL(reduced%get_value(), utest64_t(nbits))
+        END DO
+
+    END SUBROUTINE test_rpe_literal_real_64bit_defaults
+
+    @TEST
+    SUBROUTINE test_rpe_literal_real_32bit_explicit (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: nbits
+
+        DO nbits = 1, 23
+            reduced = rpe_literal(utest32, nbits)
+            @ASSERTEQUAL(utest32_t(nbits), reduced%get_value())
+        END DO
+
+    END SUBROUTINE test_rpe_literal_real_32bit_explicit
+
+    @TEST
+    SUBROUTINE test_rpe_literal_real_32bit_defaults (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: nbits
+
+        DO nbits = 1, 23
+            RPE_DEFAULT_SBITS = nbits
+            reduced = rpe_literal(utest32)
+            @ASSERTEQUAL(utest32_t(nbits), reduced%get_value())
+        END DO
+
+    END SUBROUTINE test_rpe_literal_real_32bit_defaults
+
+    @TEST
+    SUBROUTINE test_rpe_literal_integer_explicit (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: exact_value, inexact_value
+
+        exact_value = 1024  ! exact at 23-bits (default)
+        reduced = rpe_literal(exact_value)
+        @ASSERTEQUAL(reduced%get_value(), REAL(exact_value, RPE_REAL_KIND))
+        inexact_value = 10241024 ! = 10256384 at 8-bits
+        reduced = rpe_literal(inexact_value, 8)
+        @ASSERTEQUAL(reduced%get_value(), REAL(10256384, RPE_REAL_KIND))
+
+    END SUBROUTINE test_rpe_literal_integer_explicit
+
+    @TEST
+    SUBROUTINE test_rpe_literal_integer_defaults (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        INTEGER       :: exact_value, inexact_value
+
+        exact_value = 1024  ! exact at 23-bits (default)
+        reduced = rpe_literal(exact_value)
+        @ASSERTEQUAL(reduced%get_value(), REAL(exact_value, RPE_REAL_KIND))
+        inexact_value = 10241024 ! = 10256384 at 8-bits
+        RPE_DEFAULT_SBITS = 8
+        reduced = rpe_literal(inexact_value)
+        @ASSERTEQUAL(reduced%get_value(), REAL(10256384, RPE_REAL_KIND))
+
+    END SUBROUTINE test_rpe_literal_integer_defaults
+
+    @TEST
+    SUBROUTINE test_rpe_literal_long_explicit (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var)   :: reduced
+        INTEGER(KIND=8) :: exact_value, inexact_value
+
+        exact_value = 1024  ! exact at 23-bits (default)
+        reduced = rpe_literal(exact_value)
+        @ASSERTEQUAL(reduced%get_value(), REAL(exact_value, RPE_REAL_KIND))
+        inexact_value = 10241024 ! = 10256384 at 8-bits
+        reduced = rpe_literal(inexact_value, 8)
+        @ASSERTEQUAL(reduced%get_value(), REAL(10256384, RPE_REAL_KIND))
+
+    END SUBROUTINE test_rpe_literal_long_explicit
+
+    @TEST
+    SUBROUTINE test_rpe_literal_long_defaults (context)
+    ! Test that one can construct am rpe_var instance from a real number
+    ! with kind RPE_REAL_KIND.
+    !
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var)   :: reduced
+        INTEGER(KIND=8) :: exact_value, inexact_value
+
+        exact_value = 1024  ! exact at 23-bits (default)
+        reduced = rpe_literal(exact_value)
+        @ASSERTEQUAL(reduced%get_value(), REAL(exact_value, RPE_REAL_KIND))
+        inexact_value = 10241024 ! = 10256384 at 8-bits
+        RPE_DEFAULT_SBITS = 8
+        reduced = rpe_literal(inexact_value)
+        @ASSERTEQUAL(reduced%get_value(), REAL(10256384, RPE_REAL_KIND))
+
+    END SUBROUTINE test_rpe_literal_long_defaults
 
 END MODULE test_rpe_var


### PR DESCRIPTION
This PR is a backport of the changes in #6 to v3.x to support continued work with this older version.

ca8b7f1 -> df1ead6
3a46036 -> 47e5ee9