### PR TITLE
Add a standard test fixture mechanism.

### DIFF
--- a/test/unit/assignment/test_assignment_from_builtin.pf
+++ b/test/unit/assignment/test_assignment_from_builtin.pf
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -20,10 +20,15 @@ MODULE test_assignment_from_builtin
     USE rp_emulator
     IMPLICIT NONE
 
+#include "emutest_type.pf"
+
 CONTAINS
 
+#include "emutest_proc.pf"
+
     @TEST
-    SUBROUTINE test_assign_rpe_var_real_exact ()
+    SUBROUTINE test_assign_rpe_var_real_exact (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var)            :: assignee
         REAL(KIND=RPE_REAL_KIND) :: value_holder
 
@@ -35,7 +40,8 @@ CONTAINS
     END SUBROUTINE test_assign_rpe_var_real_exact
 
     @TEST
-    SUBROUTINE test_assign_rpe_var_real_truncated ()
+    SUBROUTINE test_assign_rpe_var_real_truncated (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var)            :: assignee
         REAL(KIND=RPE_REAL_KIND) :: value_holder
     
@@ -47,7 +53,8 @@ CONTAINS
     END SUBROUTINE test_assign_rpe_var_real_truncated
     
     @TEST
-    SUBROUTINE test_assign_rpe_var_alternate_exact ()
+    SUBROUTINE test_assign_rpe_var_alternate_exact (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var)                 :: assignee
         REAL(KIND=RPE_ALTERNATE_KIND) :: value_holder
 
@@ -59,7 +66,8 @@ CONTAINS
     END SUBROUTINE test_assign_rpe_var_alternate_exact
 
     @TEST
-    SUBROUTINE test_assign_rpe_var_alternate_truncated ()
+    SUBROUTINE test_assign_rpe_var_alternate_truncated (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var)                 :: assignee
         REAL(KIND=RPE_ALTERNATE_KIND) :: value_holder
     
@@ -71,7 +79,8 @@ CONTAINS
     END SUBROUTINE test_assign_rpe_var_alternate_truncated
     
     @TEST
-    SUBROUTINE test_assign_rpe_var_integer_exact ()
+    SUBROUTINE test_assign_rpe_var_integer_exact (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: assignee
         INTEGER       :: value_holder
 
@@ -82,7 +91,8 @@ CONTAINS
     END SUBROUTINE test_assign_rpe_var_integer_exact
 
     @TEST
-    SUBROUTINE test_assign_rpe_var_integer_truncated ()
+    SUBROUTINE test_assign_rpe_var_integer_truncated (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: assignee
         INTEGER       :: value_holder
 
@@ -94,7 +104,8 @@ CONTAINS
     END SUBROUTINE test_assign_rpe_var_integer_truncated
 
     @TEST
-    SUBROUTINE test_assign_rpe_var_long_exact ()
+    SUBROUTINE test_assign_rpe_var_long_exact (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var)   :: assignee
         INTEGER(KIND=8) :: value_holder
 
@@ -105,7 +116,8 @@ CONTAINS
     END SUBROUTINE test_assign_rpe_var_long_exact
 
     @TEST
-    SUBROUTINE test_assign_rpe_var_long_truncated ()
+    SUBROUTINE test_assign_rpe_var_long_truncated (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var)   :: assignee
         INTEGER(KIND=8) :: value_holder
 

--- a/test/unit/assignment/test_assignment_rpe_rpe.pf
+++ b/test/unit/assignment/test_assignment_rpe_rpe.pf
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -20,14 +20,19 @@ MODULE test_assignment_rpe_rpe
     USE rp_emulator
     IMPLICIT NONE
 
+#include "emutest_type.pf"
+
 CONTAINS
+
+#include "emutest_proc.pf"
 
 !-----------------------------------------------------------------------
 ! Assigning an `rpe_var` instance to an `rpe_var` instance.
 !
 
     @TEST
-    SUBROUTINE test_assign_rpe_var_rpe_var_sbits_default ()
+    SUBROUTINE test_assign_rpe_var_rpe_var_sbits_default (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: assignee, value_holder
         value_holder = utest64
         assignee = value_holder
@@ -35,7 +40,8 @@ CONTAINS
     END SUBROUTINE test_assign_rpe_var_rpe_var_sbits_default
 
     @TEST
-    SUBROUTINE test_assign_rpe_var_rpe_var_sbits_explicit ()
+    SUBROUTINE test_assign_rpe_var_rpe_var_sbits_explicit (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: assignee, value_holder
         value_holder%sbits = 4
         assignee%sbits = 4
@@ -45,7 +51,8 @@ CONTAINS
     END SUBROUTINE test_assign_rpe_var_rpe_var_sbits_explicit
     
     @TEST
-    SUBROUTINE test_assign_rpe_var_rpe_var_lower_to_higher ()
+    SUBROUTINE test_assign_rpe_var_rpe_var_lower_to_higher (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: assignee, value_holder
         value_holder%sbits = 16
         assignee%sbits = 4
@@ -55,7 +62,8 @@ CONTAINS
     END SUBROUTINE test_assign_rpe_var_rpe_var_lower_to_higher
 
     @TEST
-    SUBROUTINE test_assign_rpe_var_rpe_var_higher_to_lower ()
+    SUBROUTINE test_assign_rpe_var_rpe_var_higher_to_lower (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: assignee, value_holder
         value_holder%sbits = 4
         assignee%sbits = 16

--- a/test/unit/assignment/test_assignment_to_builtin.pf
+++ b/test/unit/assignment/test_assignment_to_builtin.pf
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -20,10 +20,15 @@ MODULE test_assignment_to_builtin
     USE rp_emulator
     IMPLICIT NONE
 
+#include "emutest_type.pf"
+
 CONTAINS
 
+#include "emutest_proc.pf"
+
     @TEST
-    SUBROUTINE test_assign_real_rpe_var ()
+    SUBROUTINE test_assign_real_rpe_var (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         REAL(KIND=RPE_REAL_KIND) :: assignee
         TYPE(rpe_var)            :: value_holder
 
@@ -34,7 +39,8 @@ CONTAINS
     END SUBROUTINE test_assign_real_rpe_var
 
     @TEST
-    SUBROUTINE test_assign_alternate_rpe_var ()
+    SUBROUTINE test_assign_alternate_rpe_var (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         REAL(KIND=RPE_ALTERNATE_KIND) :: assignee
         TYPE(rpe_var)                 :: value_holder
 
@@ -45,7 +51,8 @@ CONTAINS
     END SUBROUTINE test_assign_alternate_rpe_var
 
     @TEST
-    SUBROUTINE test_assign_integer_rpe_var ()
+    SUBROUTINE test_assign_integer_rpe_var (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         INTEGER       :: assignee
         TYPE(rpe_var) :: value_holder
 
@@ -56,7 +63,8 @@ CONTAINS
     END SUBROUTINE test_assign_integer_rpe_var
 
     @TEST
-    SUBROUTINE test_assign_long_rpe_var ()
+    SUBROUTINE test_assign_long_rpe_var (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         INTEGER(KIND=8) :: assignee
         TYPE(rpe_var)   :: value_holder
 

--- a/test/unit/core/test_apply_truncation.pf
+++ b/test/unit/core/test_apply_truncation.pf
@@ -22,34 +22,11 @@ MODULE test_apply_truncation
     USE rp_emulator
     IMPLICIT NONE
 
-    @TESTCASE
-    TYPE, EXTENDS(TestCase) :: EmulatorTest
-        LOGICAL :: rpe_active
-        INTEGER :: rpe_default_sbits
-        LOGICAL :: rpe_ieee_half
-        LOGICAL :: rpe_ieee_rounding
-    CONTAINS
-        procedure :: setUp
-        procedure :: tearDown
-    END TYPE EmulatorTest
+#include "emutest_type.pf"
 
 CONTAINS
 
-    SUBROUTINE setUp (this)
-        CLASS(EmulatorTest), INTENT(INOUT) :: this
-        this%rpe_active = RPE_ACTIVE
-        this%rpe_default_sbits = RPE_DEFAULT_SBITS
-        this%rpe_ieee_half = RPE_IEEE_HALF
-        this%rpe_ieee_rounding = RPE_IEEE_ROUNDING
-    END SUBROUTINE setUp
-
-    SUBROUTINE tearDown (this)
-        CLASS(EmulatorTest), INTENT(INOUT) :: this
-        RPE_ACTIVE = this%rpe_active
-        RPE_DEFAULT_SBITS = this%rpe_default_sbits
-        RPE_IEEE_HALF = this%rpe_ieee_half
-        RPE_IEEE_ROUNDING = this%rpe_ieee_rounding
-    END SUBROUTINE tearDown
+#include "emutest_proc.pf"
 
     @TEST
     SUBROUTINE test_apply_truncation_ieee_half_null (context)

--- a/test/unit/core/test_rp_emulator.pf
+++ b/test/unit/core/test_rp_emulator.pf
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -20,32 +20,15 @@ MODULE test_rp_emulator
     USE rp_emulator
     IMPLICIT NONE
 
-    @TESTCASE
-    TYPE, EXTENDS(TestCase) :: test_modify_defaults
-        INTEGER :: original_rpe_default_sbits
-    CONTAINS
-        procedure :: setUp
-        procedure :: tearDown
-    END TYPE test_modify_defaults
+#include "emutest_type.pf"
 
 CONTAINS
 
-    SUBROUTINE setUp (this)
-        ! Record the state of default values in the rp_emulator module.
-        CLASS(test_modify_defaults), INTENT(INOUT) :: this
-        this%original_rpe_default_sbits = RPE_DEFAULT_SBITS
-    END SUBROUTINE setUp
-    
-    SUBROUTINE tearDown (this)
-        ! Ensure default values are reset to their state before the test
-        ! was run.
-        CLASS(test_modify_defaults), INTENT(INOUT) :: this
-        RPE_DEFAULT_SBITS = this%original_rpe_default_sbits
-    END SUBROUTINE tearDown
+#include "emutest_proc.pf"
 
     @TEST
     SUBROUTINE test_rp_emulator_rpe_active_off (this)
-        CLASS(test_modify_defaults), INTENT(INOUT) :: this
+        CLASS(EmulatorTest), INTENT(INOUT) :: this
         TYPE(rpe_var) :: reduced
 
         RPE_ACTIVE = .FALSE.
@@ -56,7 +39,7 @@ CONTAINS
 
     @TEST
     SUBROUTINE test_rp_emulator_rpe_active_on_default (this)
-        CLASS(test_modify_defaults), INTENT(INOUT) :: this
+        CLASS(EmulatorTest), INTENT(INOUT) :: this
         TYPE(rpe_var) :: reduced
 
         RPE_ACTIVE = .TRUE.
@@ -67,7 +50,7 @@ CONTAINS
 
     @TEST
     SUBROUTINE test_rp_emulator_rpe_active_on_explicit (this)
-        CLASS(test_modify_defaults), INTENT(INOUT) :: this
+        CLASS(EmulatorTest), INTENT(INOUT) :: this
         TYPE(rpe_var) :: reduced
 
         RPE_ACTIVE = .TRUE.

--- a/test/unit/core/test_significand_bits.pf
+++ b/test/unit/core/test_significand_bits.pf
@@ -1,4 +1,4 @@
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -19,10 +19,15 @@ MODULE test_significand_bits
     USE rp_emulator
     IMPLICIT NONE
 
+#include "emutest_type.pf"
+
 CONTAINS
 
+#include "emutest_proc.pf"
+
     @TEST
-    SUBROUTINE test_significand_bits_rpe_var ()
+    SUBROUTINE test_significand_bits_rpe_var (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: input
         INTEGER       :: result, expected
 
@@ -33,7 +38,8 @@ CONTAINS
     END SUBROUTINE test_significand_bits_rpe_var
 
     @TEST
-    SUBROUTINE test_significand_bits_rpe_var_explicit ()
+    SUBROUTINE test_significand_bits_rpe_var_explicit (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         TYPE(rpe_var) :: input
         INTEGER       :: result, expected
 
@@ -45,7 +51,8 @@ CONTAINS
     END SUBROUTINE test_significand_bits_rpe_var_explicit
 
     @TEST
-    SUBROUTINE test_significand_bits_double_precision ()
+    SUBROUTINE test_significand_bits_double_precision (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         REAL(KIND=RPE_DOUBLE_KIND) :: input
         INTEGER                    :: result, expected
 
@@ -56,7 +63,8 @@ CONTAINS
     END SUBROUTINE test_significand_bits_double_precision
 
     @TEST
-    SUBROUTINE test_significand_bits_single_precision ()
+    SUBROUTINE test_significand_bits_single_precision (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         REAL(KIND=RPE_SINGLE_KIND) :: input
         INTEGER                    :: result, expected
 
@@ -67,7 +75,8 @@ CONTAINS
     END SUBROUTINE test_significand_bits_single_precision
 
     @TEST
-    SUBROUTINE test_significand_bits_integer ()
+    SUBROUTINE test_significand_bits_integer (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         INTEGER :: input
         INTEGER :: result, expected
 
@@ -78,7 +87,8 @@ CONTAINS
     END SUBROUTINE test_significand_bits_integer
 
     @TEST
-    SUBROUTINE test_significand_bits_complex ()
+    SUBROUTINE test_significand_bits_complex (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
         COMPLEX :: input
         INTEGER :: result, expected
 

--- a/test/unit/include/emutest_proc.pf
+++ b/test/unit/include/emutest_proc.pf
@@ -1,0 +1,15 @@
+SUBROUTINE setUp (this)
+    CLASS(EmulatorTest), INTENT(INOUT) :: this
+    this%rpe_active = RPE_ACTIVE
+    this%rpe_default_sbits = RPE_DEFAULT_SBITS
+    this%rpe_ieee_half = RPE_IEEE_HALF
+    this%rpe_ieee_rounding = RPE_IEEE_ROUNDING
+END SUBROUTINE setUp
+
+SUBROUTINE tearDown (this)
+    CLASS(EmulatorTest), INTENT(INOUT) :: this
+    RPE_ACTIVE = this%rpe_active
+    RPE_DEFAULT_SBITS = this%rpe_default_sbits
+    RPE_IEEE_HALF = this%rpe_ieee_half
+    RPE_IEEE_ROUNDING = this%rpe_ieee_rounding
+END SUBROUTINE tearDown

--- a/test/unit/include/emutest_type.pf
+++ b/test/unit/include/emutest_type.pf
@@ -1,0 +1,10 @@
+@TESTCASE
+TYPE, EXTENDS(TestCase) :: EmulatorTest
+    LOGICAL :: rpe_active
+    INTEGER :: rpe_default_sbits
+    LOGICAL :: rpe_ieee_half
+    LOGICAL :: rpe_ieee_rounding
+CONTAINS
+    procedure :: setUp
+    procedure :: tearDown
+END TYPE EmulatorTest

--- a/test/unit/suite.mk
+++ b/test/unit/suite.mk
@@ -4,7 +4,7 @@
 # test suite.
 #
 
-# Copyright 2015 Andrew Dawson, Peter Dueben
+# Copyright 2015-2016 Andrew Dawson, Peter Dueben
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,10 @@ test_cases: $(SRCS) $(OBJS)
 # Fortran 90 files are generated from the definition files by the program
 # pFUnitParser.py, part of pFUnit. The generated files may include C
 # preprocessor directives so have the .F90 extension.
-%.F90: %.pf
+%.pfp: %.pf
+	cpp -w -I../include $< > $@
+
+%.F90: %.pfp
 	$(PFUNIT)/bin/pFUnitParser.py $< $@
 
 # Objects are generated from Fortran 90 source via the Fortran compiler.

--- a/test/unit/types/test_rpe_var.pf
+++ b/test/unit/types/test_rpe_var.pf
@@ -20,34 +20,11 @@ MODULE test_rpe_var
     USE rp_emulator
     IMPLICIT NONE
 
-    @TESTCASE
-    TYPE, EXTENDS(TestCase) :: EmulatorTest
-        LOGICAL :: rpe_active
-        INTEGER :: rpe_default_sbits
-        LOGICAL :: rpe_ieee_half
-        LOGICAL :: rpe_ieee_rounding
-    CONTAINS
-        procedure :: setUp
-        procedure :: tearDown
-    END TYPE EmulatorTest
+#include "emutest_type.pf"
 
 CONTAINS
 
-    SUBROUTINE setUp (this)
-        CLASS(EmulatorTest), INTENT(INOUT) :: this
-        this%rpe_active = RPE_ACTIVE
-        this%rpe_default_sbits = RPE_DEFAULT_SBITS
-        this%rpe_ieee_half = RPE_IEEE_HALF
-        this%rpe_ieee_rounding = RPE_IEEE_ROUNDING
-    END SUBROUTINE setUp
-
-    SUBROUTINE tearDown (this)
-        CLASS(EmulatorTest), INTENT(INOUT) :: this
-        RPE_ACTIVE = this%rpe_active
-        RPE_DEFAULT_SBITS = this%rpe_default_sbits
-        RPE_IEEE_HALF = this%rpe_ieee_half
-        RPE_IEEE_ROUNDING = this%rpe_ieee_rounding
-    END SUBROUTINE tearDown
+#include "emutest_proc.pf"
 
     @TEST
     SUBROUTINE test_rpe_var_assign_reduce_default (context)


### PR DESCRIPTION
This prevents repeatedly defining a test fixture set that needs to be updated in different locations as changes are made to the global state variables of rpe. Now the test fixtures can be updated in one and only one place, which is nice!

From here on it is expected that all unit test modules will include the `EmulatorTest` fixture class and all test functions will accept a context.