### PR TITLE
Change default precision from 23 to 52 bits

### DIFF
--- a/doc/api/rp_emulator.rst
+++ b/doc/api/rp_emulator.rst
@@ -97,15 +97,10 @@ Variables
 
 .. f:variable:: RPE_DEFAULT_SBITS
    :type: INTEGER
-   :attrs: default=23
+   :attrs: default=52
 
    The default number of bits used in the significand of an :f:type:`rpe_var` instance when not explicitly specified.
    This takes effect internally when determining precision levels, but does not bind an :f:type:`rpe_var` instance to a particular precision level (doesn't set :f:var:`rpe_var%sbits`).
-
-   .. admonition:: Default value change
-      :class: danger
-
-      The default value will change from 23 to 52 in version 5.0
 
 
 .. f:variable:: RPE_IEEE_HALF

--- a/src/rp_emulator.F90
+++ b/src/rp_emulator.F90
@@ -45,7 +45,7 @@ MODULE rp_emulator
     LOGICAL, PUBLIC :: RPE_ACTIVE = .TRUE.
 
     !: The default number of bits to use in the reduced-precision significand.
-    INTEGER, PUBLIC :: RPE_DEFAULT_SBITS = 23
+    INTEGER, PUBLIC :: RPE_DEFAULT_SBITS = 52
 
     !: Logical flag for determining if IEEE half-precision rules should
     !: be used when operating on values with 10 bits in the significand.

--- a/test/unit/common/suite_common.f90
+++ b/test/unit/common/suite_common.f90
@@ -17,7 +17,7 @@ MODULE suite_common
 !
     USE rp_emulator
     IMPLICIT NONE
-    
+
     ! A double precision floating-point number used for testing reduction
     ! of precision. This particular choice includes an exponent incursion
     ! at 1 bit of precision. The number has the following representations:
@@ -28,10 +28,10 @@ MODULE suite_common
     !
     REAL(KIND=RPE_REAL_KIND), PARAMETER :: utest64 = z'408C86A761308B4C'
     !
-    ! An array storing the same number at significand precisions from 1 to 23
-    ! bits. These truncated representations are rounded ocrrectly.
+    ! An array storing the same number at significand precisions from 1 to 52
+    ! bits. These truncated representations are rounded correctly.
     !
-    REAL(KIND=RPE_REAL_KIND), PARAMETER, DIMENSION(23) :: utest64_t = (/ &
+    REAL(KIND=RPE_REAL_KIND), PARAMETER, DIMENSION(52) :: utest64_t = (/ &
         REAL(z'4090000000000000', RPE_REAL_KIND), & ! 1 (rounds into exponent)
         REAL(z'408C000000000000', RPE_REAL_KIND), & ! 2
         REAL(z'408C000000000000', RPE_REAL_KIND), & ! 3
@@ -54,7 +54,36 @@ MODULE suite_common
         REAL(z'408C86A700000000', RPE_REAL_KIND), & ! 20
         REAL(z'408C86A780000000', RPE_REAL_KIND), & ! 21
         REAL(z'408C86A780000000', RPE_REAL_KIND), & ! 22
-        REAL(z'408C86A760000000', RPE_REAL_KIND)  & ! 23
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 23
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 24
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 25
+        REAL(z'408C86A760000000', RPE_REAL_KIND), & ! 26
+        REAL(z'408C86A762000000', RPE_REAL_KIND), & ! 27
+        REAL(z'408C86A761000000', RPE_REAL_KIND), & ! 28
+        REAL(z'408C86A761000000', RPE_REAL_KIND), & ! 29
+        REAL(z'408C86A761400000', RPE_REAL_KIND), & ! 30
+        REAL(z'408C86A761400000', RPE_REAL_KIND), & ! 31
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 32
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 33
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 34
+        REAL(z'408C86A761300000', RPE_REAL_KIND), & ! 35
+        REAL(z'408C86A761310000', RPE_REAL_KIND), & ! 36
+        REAL(z'408C86A761308000', RPE_REAL_KIND), & ! 37
+        REAL(z'408C86A761308000', RPE_REAL_KIND), & ! 38
+        REAL(z'408C86A761308000', RPE_REAL_KIND), & ! 39
+        REAL(z'408C86A761309000', RPE_REAL_KIND), & ! 40
+        REAL(z'408C86A761308800', RPE_REAL_KIND), & ! 41
+        REAL(z'408C86A761308C00', RPE_REAL_KIND), & ! 42
+        REAL(z'408C86A761308C00', RPE_REAL_KIND), & ! 43
+        REAL(z'408C86A761308B00', RPE_REAL_KIND), & ! 44
+        REAL(z'408C86A761308B80', RPE_REAL_KIND), & ! 45
+        REAL(z'408C86A761308B40', RPE_REAL_KIND), & ! 46
+        REAL(z'408C86A761308B40', RPE_REAL_KIND), & ! 47
+        REAL(z'408C86A761308B50', RPE_REAL_KIND), & ! 48
+        REAL(z'408C86A761308B50', RPE_REAL_KIND), & ! 49
+        REAL(z'408C86A761308B4C', RPE_REAL_KIND), & ! 50
+        REAL(z'408C86A761308B4C', RPE_REAL_KIND), & ! 51
+        REAL(z'408C86A761308B4C', RPE_REAL_KIND)  & ! 52
     /)
 
     ! A double precision floating-point number used for testing reduction
@@ -127,7 +156,7 @@ MODULE suite_common
         REAL(z'408C86A761308B44', RPE_REAL_KIND), & ! 51
         REAL(z'408C86A761308B44', RPE_REAL_KIND)  & ! 52
     /)
-    
+
     REAL(KIND=RPE_ALTERNATE_KIND), PARAMETER :: utest32 = z'404ccccd'
     REAL(KIND=RPE_REAL_KIND),      PARAMETER :: utest32_64 = z'40099999A0000000'
     REAL(KIND=RPE_ALTERNATE_KIND), PARAMETER, DIMENSION(23) :: utest32_t = (/ &

--- a/test/unit/types/test_rpe_var.pf
+++ b/test/unit/types/test_rpe_var.pf
@@ -36,7 +36,7 @@ CONTAINS
         TYPE(rpe_var) :: reduced
 
         reduced = utest64
-        @ASSERTEQUAL(reduced%val, utest64_t(23))
+        @ASSERTEQUAL(reduced%val, utest64_t(52))
 
     END SUBROUTINE test_rpe_var_assign_reduce_default
 
@@ -50,7 +50,7 @@ CONTAINS
         TYPE(rpe_var) :: reduced
         INTEGER       :: nbits
 
-        DO nbits = 1, 23
+        DO nbits = 1, 52
             reduced%sbits = nbits
             reduced = utest64
             @ASSERTEQUAL(reduced%val, utest64_t(nbits))
@@ -67,7 +67,7 @@ CONTAINS
         TYPE(rpe_var) :: reduced
         INTEGER       :: nbits
 
-        DO nbits = 1, 23
+        DO nbits = 1, 52
             reduced = rpe_literal(utest64, nbits)
             @ASSERTEQUAL(reduced%val, utest64_t(nbits))
         END DO
@@ -83,7 +83,7 @@ CONTAINS
         TYPE(rpe_var) :: reduced
         INTEGER       :: nbits
 
-        DO nbits = 1, 23
+        DO nbits = 1, 52
             RPE_DEFAULT_SBITS = nbits
             reduced = rpe_literal(utest64)
             @ASSERTEQUAL(reduced%val, utest64_t(nbits))
@@ -133,8 +133,8 @@ CONTAINS
         TYPE(rpe_var) :: reduced
         INTEGER       :: exact_value, inexact_value
 
-        exact_value = 1024  ! exact at 23-bits (default)
-        reduced = rpe_literal(exact_value)
+        exact_value = 1024  ! exact at 23-bits
+        reduced = rpe_literal(exact_value, 23)
         @ASSERTEQUAL(reduced%val, REAL(exact_value, RPE_REAL_KIND))
         inexact_value = 10241024 ! = 10256384 at 8-bits
         reduced = rpe_literal(inexact_value, 8)
@@ -151,7 +151,8 @@ CONTAINS
         TYPE(rpe_var) :: reduced
         INTEGER       :: exact_value, inexact_value
 
-        exact_value = 1024  ! exact at 23-bits (default)
+        exact_value = 1024  ! exact at 23-bits
+        RPE_DEFAULT_SBITS = 23
         reduced = rpe_literal(exact_value)
         @ASSERTEQUAL(reduced%val, REAL(exact_value, RPE_REAL_KIND))
         inexact_value = 10241024 ! = 10256384 at 8-bits
@@ -170,8 +171,8 @@ CONTAINS
         TYPE(rpe_var)   :: reduced
         INTEGER(KIND=8) :: exact_value, inexact_value
 
-        exact_value = 1024  ! exact at 23-bits (default)
-        reduced = rpe_literal(exact_value)
+        exact_value = 1024  ! exact at 23-bits
+        reduced = rpe_literal(exact_value, 23)
         @ASSERTEQUAL(reduced%val, REAL(exact_value, RPE_REAL_KIND))
         inexact_value = 10241024 ! = 10256384 at 8-bits
         reduced = rpe_literal(inexact_value, 8)
@@ -188,7 +189,8 @@ CONTAINS
         TYPE(rpe_var)   :: reduced
         INTEGER(KIND=8) :: exact_value, inexact_value
 
-        exact_value = 1024  ! exact at 23-bits (default)
+        exact_value = 1024  ! exact at 23-bits
+        RPE_DEFAULT_SBITS = 23
         reduced = rpe_literal(exact_value)
         @ASSERTEQUAL(reduced%val, REAL(exact_value, RPE_REAL_KIND))
         inexact_value = 10241024 ! = 10256384 at 8-bits


### PR DESCRIPTION
This change sets the default value of `RPE_DEFAULT_SBITS` to 52, previously it was 23. We used to use single precision within the emulator, meaning 23-bits was actually no truncation at all. A long time ago we switched to double precision internally, but kept the default truncation at 23 significand bits. This change means we go back to having a default of no truncation. The default is arbitrary, we can never pick a truly useful one, and setting it to 52 should avoid some confusion.