### PR TITLE
Fix the upper range for IEEE half-precision values

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,14 @@ v5.0.x
 :Release: v5.0.0
 :Date:
 
+* Major changes
+
+  * The upper limit for the value of an IEEE half-precision number has been
+    corrected to 65504. This value was previously too small (32768) resulting
+    in an over-conservative representation of IEEE half-precision values. This
+    change only affects code running with the ``RPE_IEEE_HALF`` option turned
+    on.
+
 * Incompatibilities
 
   * The rounding mode has changed to be compliant with IEEE 754. The new mode

--- a/src/rp_emulator.F90
+++ b/src/rp_emulator.F90
@@ -241,7 +241,7 @@ CONTAINS
         REAL(KIND=RPE_DOUBLE_KIND)            :: y
         REAL(KIND=RPE_DOUBLE_KIND), PARAMETER :: two = 2.0_RPE_DOUBLE_KIND
         REAL(KIND=RPE_DOUBLE_KIND)            :: sx, d1, d2
-        IF (ABS(x) > two ** 15) THEN
+        IF (ABS(x) > 65504.0_RPE_DOUBLE_KIND) THEN
         ! Handle half-precision overflows.
             sx = SIGN(1.0_RPE_DOUBLE_KIND, x)
             d1 = HUGE(d1) * sx

--- a/test/unit/core/test_apply_truncation.pf
+++ b/test/unit/core/test_apply_truncation.pf
@@ -57,10 +57,10 @@ CONTAINS
         RPE_DEFAULT_SBITS = 10
         RPE_IEEE_HALF = .TRUE.
 
-        reduced = 32800
+        reduced = 655040
         @ASSERTTRUE(reduced > HUGE(1.0_RPE_REAL_KIND))
 
-        reduced = -32800
+        reduced = -655040
         @ASSERTTRUE(reduced < -HUGE(1.0_RPE_REAL_KIND))
     END SUBROUTINE test_apply_truncation_ieee_half_overflow
 


### PR DESCRIPTION
Sets the maximum allowed value for IEEE half-precision values to 65504. Closes #15.