### PR TITLE
Minor refinements to Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
 # Makefile for the reduced-precision emulator.
 #
-# Uses a two-stage build, first the full library source is generated
-# manually using the C preprocessor, which yields a single source file
-# which can be compiled into the emulator library and associated module.
-#
 
 # Copyright 2015-2016 Andrew Dawson, Peter Dueben
 #
@@ -55,9 +51,8 @@ library: $(libstatic)
 shared: $(libshared)
 
 # Compile the emulator source to generate a module and an object file:
-$(object): $(src) $(geninc)
+$(object) $(module): $(src) $(geninc)
 	$(F90) -c -I$(genincdir) $(FFLAGS) -fPIC $(src) -o $(object)
-$(module): $(src) $(object)
 
 # Create a library archive from the compiled code:
 $(libstatic): $(object)

--- a/test/integration/lorenz63/Makefile
+++ b/test/integration/lorenz63/Makefile
@@ -44,9 +44,8 @@ l63_reference: $(refexe)
 l63_reduced: $(redexe)
 
 # Build the command line support library:
-$(cliobj): $(clisrc)
+$(cliobj) $(climod): $(clisrc)
 	$(F90) -c $^
-$(climod): $(cliobj)
 
 # Reference model executable:
 $(refobj): $(refsrc)


### PR DESCRIPTION
Use multiple targets to compile fortran modules, and correct out-of-date docstring.