### PR TITLE
Fix huge intrinsic

### DIFF
--- a/generator/configs/intrinsics.json
+++ b/generator/configs/intrinsics.json
@@ -6,12 +6,6 @@
                 "interface_types": ["1argscalar"]
             }
         },
-        {"huge":
-            {
-                "return_type": "rpe_var",
-                "interface_types": ["1argscalar"]
-            }
-        },
         {"tiny":
             {
                 "return_type": "rpe_var",

--- a/src/include/implementation_extras.f90
+++ b/src/include/implementation_extras.f90
@@ -1,0 +1,42 @@
+    !-------------------------------------------------------------------
+    ! Hand-written overloaded definition for 'huge'
+    !
+    ! This function behaves differently than others for reduced
+    ! precision. If we simply round the result of the HUGE intrinsic we
+    ! will always yield infinity, since HUGE will return a value with
+    ! a full significand.
+    !
+    ! This implementation performs truncation of the value returned by
+    ! the HUGE intrinsic *without* doing rounding, which produces the
+    ! correct result.
+    !
+    ! Note that we must also manually check if the emulator is turend on
+    ! before performing the truncation (this is normally done by the
+    ! overloaded assignment operator, but we are not using it here).
+    !
+
+    FUNCTION huge_rpe (a) RESULT (x)
+        TYPE(rpe_var), INTENT(IN) :: a
+        TYPE(rpe_var) :: x
+        INTEGER                    :: lmtb
+        INTEGER(KIND=8), PARAMETER :: zero_bits = 0
+        INTEGER(KIND=8)            :: bits
+        x%sbits = significand_bits(a)
+        x%val = HUGE(a%val)
+        IF (RPE_ACTIVE) THEN
+            IF ((x%sbits == 10) .AND. (RPE_IEEE_HALF)) THEN
+                ! For half precision emulation we need to specify the value
+                ! explicitly, HUGE cannot do this in the absence of a native
+                ! 16-bit real type:
+                x%val = 65504
+            ELSE
+                ! Truncate to the required size without rounding, applying
+                ! rounding will always round to infinity and is therefore no
+                ! good for this purpose:
+                lmtb = 52 - x%sbits - 1
+                bits = TRANSFER(x%val, bits)
+                CALL MVBITS (zero_bits, 0, lmtb + 1, bits, 0)
+                x%val = TRANSFER(bits, x%val)
+            END IF
+        END IF
+    END FUNCTION huge_rpe

--- a/src/include/implementation_intrinsics.f90
+++ b/src/include/implementation_intrinsics.f90
@@ -10,17 +10,6 @@
     END FUNCTION epsilon_rpe
 
     !-------------------------------------------------------------------
-    ! Overloaded definitions for 'huge':
-    !
-
-    FUNCTION huge_rpe (a) RESULT (x)
-        TYPE(rpe_var), INTENT(IN) :: a
-        TYPE(rpe_var) :: x
-        x%sbits = significand_bits(a)
-        x = HUGE(a%val)
-    END FUNCTION huge_rpe
-
-    !-------------------------------------------------------------------
     ! Overloaded definitions for 'tiny':
     !
 

--- a/src/include/interface_extras.i
+++ b/src/include/interface_extras.i
@@ -1,0 +1,4 @@
+    PUBLIC :: huge
+    INTERFACE huge
+        MODULE PROCEDURE huge_rpe
+    END INTERFACE huge

--- a/src/include/interface_intrinsics.i
+++ b/src/include/interface_intrinsics.i
@@ -3,11 +3,6 @@
         MODULE PROCEDURE epsilon_rpe
     END INTERFACE epsilon
 
-    PUBLIC :: huge
-    INTERFACE huge
-        MODULE PROCEDURE huge_rpe
-    END INTERFACE huge
-
     PUBLIC :: tiny
     INTERFACE tiny
         MODULE PROCEDURE tiny_rpe

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,7 +1,7 @@
 # Makefile for the reduced-precision emulator unit test driver.
 #
 
-# Copyright 2015 Andrew Dawson, Peter Dueben
+# Copyright 2015-2016 Andrew Dawson, Peter Dueben
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 include $(PFUNIT)/include/base.mk
 
 # A list of all test modules that should be built.
-TEST_MODULES = core types assignment
+TEST_MODULES = core types assignment intrinsics
 
 # Phony targets for building external test modules (where the tests are
 # actually implemented).

--- a/test/unit/intrinsics/Makefile
+++ b/test/unit/intrinsics/Makefile
@@ -1,0 +1,19 @@
+# Makefile for the intrinsics test module
+#
+
+# Copyright 2016 Andrew Dawson, Peter Dueben
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The base suite makefile is sufficient for building this suite.
+include ../suite.mk

--- a/test/unit/intrinsics/test_huge.pf
+++ b/test/unit/intrinsics/test_huge.pf
@@ -1,0 +1,94 @@
+! Copyright 2016 Andrew Dawson, Peter Dueben
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+MODULE test_huge
+! Tests for the `huge` intrinsic
+!
+! This intrinsic is hand-written and requires dedicated testing.
+!
+    USE pfunit_mod
+    USE rp_emulator
+    IMPLICIT NONE
+
+#include "emutest_type.pf"
+
+CONTAINS
+
+#include "emutest_proc.pf"
+
+    @TEST
+    SUBROUTINE test_huge_default (context)
+    ! Test the
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        REAL(KIND=RPE_REAL_KIND) :: t
+        INTEGER :: sbits
+        ! With 52-bit precision the result should match the intrinsic HUGE
+        ! exactly:
+        t = HUGE(t)
+        reduced = HUGE(reduced)
+        @ASSERTEQUAL(reduced%val, t)
+        ! With lower precision the result should be smaller than the result
+        ! of the intrinsic HUGE:
+        DO sbits = 0, 51
+            reduced%sbits = sbits
+            reduced = HUGE(reduced)
+            @ASSERTLESSTHAN(reduced%val, t)
+        END DO
+    END SUBROUTINE test_huge_default
+
+    @TEST
+    SUBROUTINE test_huge_deactivated (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        REAL(KIND=RPE_REAL_KIND) :: t
+        INTEGER :: sbits
+        ! With the emulator off the result should match the intrinsic HUGE
+        ! exactly:
+        RPE_ACTIVE = .false.
+        t = HUGE(t)
+        DO sbits = 0, 52
+            reduced%sbits = sbits
+            reduced = HUGE(reduced)
+            @ASSERTEQUAL(reduced%val, t)
+        END DO
+    END SUBROUTINE test_huge_deactivated
+
+    @TEST
+    SUBROUTINE test_huge_ieee_half (context)
+        CLASS(EmulatorTest), INTENT(INOUT) :: context
+        TYPE(rpe_var) :: reduced
+        REAL(KIND=RPE_REAL_KIND) :: t
+        INTEGER :: sbits
+        ! With 52-bit precision the result should match the intrinsic HUGE
+        ! exactly:
+        t = HUGE(t)
+        reduced = HUGE(reduced)
+        @ASSERTEQUAL(reduced%val, t)
+        ! With the emulator in half-precision mode the result should be the
+        ! largest 16-bit float (65504):
+        RPE_IEEE_HALF = .true.
+        reduced%sbits = 10
+        reduced = HUGE(reduced)
+        @ASSERTEQUAL(reduced%val, 65504)
+        ! With lower precision the result should be smaller than the result
+        ! of the intrinsic HUGE:
+        DO sbits = 0, 51
+            reduced%sbits = sbits
+            reduced = HUGE(reduced)
+            @ASSERTLESSTHAN(reduced%val, t)
+        END DO
+    END SUBROUTINE test_huge_ieee_half
+
+END MODULE test_huge

--- a/test/unit/testSuites.inc
+++ b/test/unit/testSuites.inc
@@ -3,7 +3,7 @@
 ! If a suite does not have an entry in this file it will not be included
 ! in the test driver application.
 !
-! Copyright 2015 Andrew Dawson, Peter Dueben
+! Copyright 2015-2016 Andrew Dawson, Peter Dueben
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -29,3 +29,6 @@ ADD_TEST_SUITE(test_rpe_var_suite)
 ADD_TEST_SUITE(test_assignment_to_builtin_suite)
 ADD_TEST_SUITE(test_assignment_from_builtin_suite)
 ADD_TEST_SUITE(test_assignment_rpe_rpe_suite)
+
+! Test suites for intrinsic functions.
+ADD_TEST_SUITE(test_huge_suite)


### PR DESCRIPTION
As described in #11, the `huge` intrinsic overload was returning infinity for truncated variables. This is because `huge` returns a number with a full significand, that when truncated will always be rounded producing infinity.

This PR addresses the problem by providing a hand-written version of the `huge` overload, that computes the correct value by truncating the result of the intrinsic `huge` *without rounding*. This requires extra care to detect emulator state, since the overloaded assignment is bypassed.

Closes #11.